### PR TITLE
[18.0][FIX] mail_debrand: ensure footer is rendered in test

### DIFF
--- a/mail_debrand/tests/test_mail_debrand.py
+++ b/mail_debrand/tests/test_mail_debrand.py
@@ -40,6 +40,7 @@ class TestMailDebrand(common.TransactionCase):
             {
                 "message": self.mail,
                 "company": self.env.company,
+                "email_notification_force_footer": True,
             },
             lang=lang.code,
             minimal_qcontext=True,


### PR DESCRIPTION
See https://github.com/odoo/odoo/commit/9f65f1a

Fixes
```
2025-02-12 16:01:58,174 254 ERROR odoo odoo.addons.mail_debrand.tests.test_mail_debrand: FAIL: TestMailDebrand.test_default_debrand
Traceback (most recent call last):
  File "/__w/mail/mail/mail_debrand/tests/test_mail_debrand.py", line 52, in test_default_debrand
    self._test_debrand_by_lang(
  File "/__w/mail/mail/mail_debrand/tests/test_mail_debrand.py", line 47, in _test_debrand_by_lang
    self.assertIn(term, body)
AssertionError: 'Powered by' not found in Markup('\n<html>\n<head>\n
... 
```