### PR TITLE
[18.0][FIX] mail_outbound_static: Use the function formataddr() from odoo.tools instead of email.utils.

### DIFF
--- a/mail_outbound_static/__manifest__.py
+++ b/mail_outbound_static/__manifest__.py
@@ -7,7 +7,7 @@
     "version": "18.0.1.0.0",
     "category": "Discuss",
     "website": "https://github.com/OCA/mail",
-    "author": "brain-tec AG, LasLabs, Adhoc SA, Odoo Community Association (OCA)",
+    "author": "braintec AG, LasLabs, Adhoc SA, Odoo Community Association (OCA)",
     "license": "LGPL-3",
     "application": False,
     "installable": True,

--- a/mail_outbound_static/models/ir_mail_server.py
+++ b/mail_outbound_static/models/ir_mail_server.py
@@ -2,10 +2,11 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 import re
-from email.utils import formataddr, parseaddr
+from email.utils import parseaddr
 
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import ValidationError
+from odoo.tools import formataddr
 
 
 class IrMailServer(models.Model):
@@ -84,7 +85,7 @@ class IrMailServer(models.Model):
         ):
             email_from = formataddr((name_from, mail_server.smtp_from))
             message.replace_header("From", email_from)
-            smtp_from = email_from
+            smtp_from = mail_server.smtp_from
             if not self._get_default_bounce_address():
                 # then, bounce handling is disabled and we want
                 # Return-Path = From

--- a/mail_outbound_static/readme/CONTRIBUTORS.md
+++ b/mail_outbound_static/readme/CONTRIBUTORS.md
@@ -1,4 +1,4 @@
-- Frédéric Garbely \<<frederic.garbely@braintec-group.com>\>
+- Frédéric Garbely \<<frederic.garbely@braintec.com>\>
 - Dave Lasley \<<dave@laslabs.com>\>
 - Lorenzo Battistini \<<https://github.com/eLBati>\>
 - Pierre Pizzetta \<<pierre@devreaction.com>\>

--- a/mail_outbound_static/tests/test_ir_mail_server.py
+++ b/mail_outbound_static/tests/test_ir_mail_server.py
@@ -196,7 +196,7 @@ class TestIrMailServer(TransactionCase, MockSmtplibCase):
         with self.mock_smtplib_connection():
             message = self._send_mail(self.message)
         self.assertEqual(
-            message["From"], f"Mitchell Admin <{expected_mail_server.smtp_from}>"
+            message["From"], f'"Mitchell Admin" <{expected_mail_server.smtp_from}>'
         )
 
         used_mail_server = self.IrMailServer._get_mail_sever(domain)
@@ -372,3 +372,28 @@ class TestIrMailServer(TransactionCase, MockSmtplibCase):
             mail_server.smtp_from = "."
 
         mail_server.smtp_from = "notifications@test.com"
+
+    def test_11_from_outgoing_server_another_special_char_comma(self):
+        self._init_mail_server_domain_whilelist_based()
+        domain = "example.com"
+        email_from = f'"Muster, Jörg" <admin@{domain}>'
+        expected_mail_server = self.mail_server_domainone
+
+        self.message.replace_header("From", email_from)
+        # A mail server is configured for the email
+        with self.mock_smtplib_connection():
+            message = self._send_mail(self.message)
+        self.assertEqual(
+            message["From"], f'"Muster, Jörg" <{expected_mail_server.smtp_from}>'
+        )
+
+        used_mail_server = self.IrMailServer._get_mail_sever(domain)
+        used_mail_server = self.IrMailServer.browse(used_mail_server)
+        self.assertEqual(
+            used_mail_server,
+            expected_mail_server,
+            (
+                f"It using {used_mail_server.name}"
+                f" but we expect to use {expected_mail_server.name}"
+            ),
+        )


### PR DESCRIPTION
Until now, the function `formataddr()` from `email.utils` has been used.
This leads to a problem if the sender's name contains at least one comma and at least one special character (e.g. `ü`).

Simplified example:
`formataddr('Schmid, Jürgen', 'sch.j@example.com')` results in `Schmid, Jürgen <sch.j@example.com>`.
That's wrong, because the mail servers interpret it as multiple addresses. 

Now, we can use the function `formataddr()` from `odoo.tools`.

The same example:
`formataddr('Schmid, Jürgen', 'sch.j@example.com')` results in `"Schmid, Jürgen" <sch.j@example.com>`.
That's correct.