### PR TITLE
[FIX] mail_tracking: python warning deprecated utcfromtimestamp

### DIFF
--- a/mail_tracking/models/mail_mail.py
+++ b/mail_tracking/models/mail_mail.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from email.utils import COMMASPACE
 
 from odoo import fields, models
@@ -14,7 +14,7 @@ class MailMail(models.Model):
     def _tracking_email_prepare(self, email):
         """Prepare email.tracking.email record values"""
         ts = time.time()
-        dt = datetime.utcfromtimestamp(ts)
+        dt = datetime.fromtimestamp(ts, timezone.utc)
         email_to_list = email.get("email_to", [])
         email_to = COMMASPACE.join(email_to_list)
         return {

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -6,7 +6,7 @@ import re
 import time
 import urllib.parse
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import AccessError
@@ -434,7 +434,7 @@ class MailTrackingEmail(models.Model):
     def _tracking_sent_prepare(self, mail_server, smtp_server, message, message_id):
         self.ensure_one()
         ts = time.time()
-        dt = datetime.utcfromtimestamp(ts)
+        dt = datetime.fromtimestamp(ts, timezone.utc)
         self._message_partners_check(message, message_id)
         self.sudo().write({"state": "sent"})
         return {

--- a/mail_tracking/models/mail_tracking_event.py
+++ b/mail_tracking/models/mail_tracking_event.py
@@ -3,7 +3,7 @@
 
 import re
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 from odoo import api, fields, models
 
@@ -84,7 +84,7 @@ class MailTrackingEvent(models.Model):
 
     def _process_data(self, tracking_email, metadata, event_type, state):
         ts = time.time()
-        dt = datetime.utcfromtimestamp(ts)
+        dt = datetime.fromtimestamp(ts, timezone.utc)
         return {
             "recipient": metadata.get("recipient", tracking_email.recipient),
             "timestamp": metadata.get("timestamp", ts),


### PR DESCRIPTION
DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).