### PR TITLE
[18.0][FIX] mail_tracking: email_to without comma bug

### DIFF
--- a/mail_tracking/models/mail_mail.py
+++ b/mail_tracking/models/mail_mail.py
@@ -3,7 +3,6 @@
 
 import time
 from datetime import datetime
-from email.utils import COMMASPACE
 
 from odoo import fields, models
 
@@ -15,8 +14,7 @@ class MailMail(models.Model):
         """Prepare email.tracking.email record values"""
         ts = time.time()
         dt = datetime.utcfromtimestamp(ts)
-        email_to_list = email.get("email_to", [])
-        email_to = COMMASPACE.join(email_to_list)
+        email_to = email.get("email_to", "")
         return {
             "name": self.subject,
             "timestamp": f"{ts:.6f}",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/579d44c7-92ef-490c-bb6c-84be2f6a34d5)

`mail.mail email_to` had comma between each character. Not so anymore.

![image](https://github.com/user-attachments/assets/9b7a032c-795d-435f-ac03-76d9ef83ea1e)

![image](https://github.com/user-attachments/assets/00eafcbd-4e9c-4bd4-a3df-d13cfc1c5533)
