### PR TITLE
[18.0][FIX] mail_composer_cc_bcc: emails list

### DIFF
--- a/mail_composer_cc_bcc/models/mail_mail.py
+++ b/mail_composer_cc_bcc/models/mail_mail.py
@@ -8,12 +8,15 @@ from odoo.addons.base.models.ir_mail_server import extract_rfc2822_addresses
 
 
 def format_emails(partners):
-    emails = [tools.formataddr((p.name or "", p.email)) for p in partners if p.email]
-    return ", ".join(emails)
+    return [tools.formataddr((p.name or "", p.email)) for p in partners if p.email]
 
 
 def format_emails_raw(partners):
-    emails = [p.email for p in partners if p.email]
+    return [p.email for p in partners if p.email]
+
+
+def format_emails_str(partners):
+    emails = format_emails(partners)
     return ", ".join(emails)
 
 
@@ -42,7 +45,7 @@ class MailMail(models.Model):
         partner_to = self.env["res.partner"].browse(partner_to_ids)
         email_to = format_emails(partner_to)
         email_to_raw = format_emails_raw(partner_to)
-        email_cc = format_emails(self.recipient_cc_ids)
+        email_cc = format_emails_str(self.recipient_cc_ids)
         email_bcc = [r.email for r in self.recipient_bcc_ids if r.email]
 
         # Collect recipients (RCPT TO) and update all emails

--- a/mail_composer_cc_bcc/models/mail_thread.py
+++ b/mail_composer_cc_bcc/models/mail_thread.py
@@ -3,7 +3,7 @@
 
 from odoo import models
 
-from .mail_mail import format_emails
+from .mail_mail import format_emails_str
 
 
 class MailThread(models.AbstractModel):
@@ -40,11 +40,11 @@ class MailThread(models.AbstractModel):
 
         partners_cc = context.get("partner_cc_ids", None)
         if partners_cc:
-            res["email_cc"] = format_emails(partners_cc)
+            res["email_cc"] = format_emails_str(partners_cc)
 
         partners_bcc = context.get("partner_bcc_ids", None)
         if partners_bcc:
-            res["email_bcc"] = format_emails(partners_bcc)
+            res["email_bcc"] = format_emails_str(partners_bcc)
 
         return res
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/66e44a0f-c6b5-4128-a1b3-ce39dbcbf353)

`mail.mail.email_to` had comma between each character. Not so anymore.

![image](https://github.com/user-attachments/assets/ef46abc2-faab-4c61-9776-ae40b3722001)
