### PR TITLE
[18.0] mail_tracking: Apply read restrictions to everyone not being superuser

### DIFF
--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -152,7 +152,7 @@ class MailTrackingEmail(models.Model):
         _check_access() for more details about those rules.
         """
         query = super()._search(domain, offset, limit, order)
-        if not self.env.user.has_group("base.group_system"):
+        if not self.env.is_superuser():
             records = self.browse(query)
             allowed_ids = self._get_allowed_ids(records.ids)
             return self.browse(allowed_ids)._as_query(order)


### PR DESCRIPTION
The previous condition to apply access restriction to mail tracking email records was not applied to every user having access rights settings. Hence, this could lead up to AccessError when trying to open the model's action through the web client.

Since the access to these records is based on the same restrictions that are implemented for mail.message model in the mail module, we ended up having access error as there were records we were allowed to search but not to read, due to the restriction being more permissive in the case of mail tracking email.

But since the check_access method of this model is actually checking if the user has access to the related mail.message, we need to have the same conditions to avoid such access error for users with settings access that are not superuser.