### PR TITLE
[18.0][FIX] mail_composer_cc_bcc: Support placeholders

### DIFF
--- a/mail_composer_cc_bcc/README.rst
+++ b/mail_composer_cc_bcc/README.rst
@@ -115,6 +115,8 @@ Contributors
      - Son Ho <sonhd@trobz.com>
      - Tri Doan <tridm@trobz.com>
 
+- Alberto Nieto alberto.nieto@braintec.com (https://braintec.com)
+
 Other credits
 -------------
 

--- a/mail_composer_cc_bcc/readme/CONTRIBUTORS.md
+++ b/mail_composer_cc_bcc/readme/CONTRIBUTORS.md
@@ -3,3 +3,5 @@
   > - Hai N. Le \<<hailn@trobz.com>\>
   > - Son Ho \<<sonhd@trobz.com>\>
   > - Tri Doan \<<tridm@trobz.com>\>
+
+* Alberto Nieto <alberto.nieto@braintec.com> (https://braintec.com)

--- a/mail_composer_cc_bcc/static/description/index.html
+++ b/mail_composer_cc_bcc/static/description/index.html
@@ -452,6 +452,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </blockquote>
 </li>
+<li><p class="first">Alberto Nieto <a class="reference external" href="mailto:alberto.nieto&#64;braintec.com">alberto.nieto&#64;braintec.com</a> (<a class="reference external" href="https://braintec.com">https://braintec.com</a>)</p>
+</li>
 </ul>
 </div>
 <div class="section" id="other-credits">

--- a/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
+++ b/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
@@ -159,6 +159,54 @@ Test Template<br></p>""",
         expecting = self.partner_cc2 + self.partner_bcc
         self.assertEqual(composer.partner_bcc_ids, expecting)
 
+    def test_template_cc_bcc_with_placeholders(self):
+        """Test that template with placeholders for email_cc and email_bcc"""
+        # Add child record to test_record
+        self.test_record.child_ids |= (
+            self.partner_cc + self.partner_cc2 + self.partner_cc3
+        )
+
+        # Partner template values
+        tmpl_model = self.env["ir.model"].search([("model", "=", "res.partner")])
+        vals = {
+            "name": "Product Template: Re: [E-COM11] Cabinet with Doors",
+            "model_id": tmpl_model.id,
+            "subject": "Re: [E-COM11] Cabinet with Doors",
+            "body_html": """<p style="margin:0px 0 12px 0;box-sizing:border-box;">
+Test Template<br></p>""",
+            # Use placeholders
+            "email_cc": "{{ ','.join(object.mapped('child_ids.email')) }}",
+            "email_bcc": "{{ ','.join(object.mapped('child_ids.email')) }}",
+        }
+        partner_tmpl = self.env["mail.template"].create(vals)
+
+        # Open mail composer form and check for default values from company
+        form = self.open_mail_composer_form()
+        composer = form.save()
+
+        form = Form(composer)
+        form.template_id = partner_tmpl
+        composer = form.save()
+        expecting = self.partner_cc + self.partner_cc2 + self.partner_cc3
+
+        self.assertEqual(composer.partner_cc_ids, expecting)
+        self.assertEqual(composer.partner_bcc_ids, expecting)
+        # But not add Marc Demo from cc field to partner_ids field
+        self.assertEqual(len(composer.partner_ids), 1)
+        self.assertEqual(composer.partner_ids.display_name, "Test")
+
+        # Selecting the template again doesn't add as the partners already
+        # in the list
+        form = Form(composer)
+        form.template_id = self.env["mail.template"]
+        form.save()
+        self.assertFalse(form.template_id)  # no template
+
+        form.template_id = partner_tmpl
+        composer = form.save()
+        self.assertEqual(composer.partner_cc_ids, expecting)
+        self.assertEqual(composer.partner_bcc_ids, expecting)
+
     def set_company(self):
         company = self.env.company
         # Company default values

--- a/mail_composer_cc_bcc/wizards/mail_compose_message.py
+++ b/mail_composer_cc_bcc/wizards/mail_compose_message.py
@@ -55,11 +55,22 @@ class MailComposeMessage(models.TransientModel):
                 and composer.composition_mode == "comment"
                 and not composer.composition_batch
             ):
+                res_ids = composer._evaluate_res_ids() or [0]
+                rendered_values = composer._generate_template_for_composer(
+                    res_ids,
+                    {"email_cc"},
+                    find_or_create_partners=False,
+                )[res_ids[0]]
                 composer._set_partner_ids_from_mails(
-                    composer.template_id.email_cc, "partner_cc_ids"
+                    rendered_values.get("email_cc"), "partner_cc_ids"
                 )
+                rendered_values = composer._generate_template_for_composer(
+                    res_ids,
+                    {"email_bcc"},
+                    find_or_create_partners=False,
+                )[res_ids[0]]
                 composer._set_partner_ids_from_mails(
-                    composer.template_id.email_bcc, "partner_bcc_ids"
+                    rendered_values.get("email_bcc"), "partner_bcc_ids"
                 )
             elif composer.parent_id and composer.composition_mode == "comment":
                 composer.partner_cc_ids = composer.parent_id.partner_cc_ids


### PR DESCRIPTION
With the previous code, the placeholders on the mail template are not supported. This PR adds the support for those placeholders.