### PR TITLE
[FIX] mail_message_search : prevent db crach

### DIFF
--- a/mail_message_search/models/mail_thread.py
+++ b/mail_message_search/models/mail_thread.py
@@ -26,8 +26,10 @@ class MailThread(models.AbstractModel):
                 word_domain_list.append(expression.OR(field_domain_list))
         word_domain = expression.AND(word_domain_list)
         domain = expression.AND([[("model", "=", self._name)], word_domain])
-        messages = self.env["mail.message"].search(domain)
-        return [("id", "in", messages.mapped("res_id"))]
+        limit_value = self.env['ir.config_parameter'].sudo().get_param("mail.message.search.limit")
+        limit = int(limit_value) if limit_value else None
+        messages = self.env["mail.message"]._search(domain, limit=limit)
+        return [("id", "in", messages.subselect("res_id"))]
 
     message_search = fields.Text(
         help="Message search, to be used only in searches",


### PR DESCRIPTION
Before this commit a search in large database can crash, because the return of search() can include million of ids.

This PR use SQL (and not python).
A limit can be set to prevent a crash.