### PR TITLE
[18.0][IMP]mail_quoted_reply: add reply to all

### DIFF
--- a/mail_quoted_reply/models/mail_message.py
+++ b/mail_quoted_reply/models/mail_message.py
@@ -41,10 +41,13 @@ class MailMessage(models.Model):
             str_from=_("From"),
         )
 
-    def _default_reply_partner(self):
-        return self.env["res.partner"].find_or_create(self.email_from).ids
+    def _default_reply_partner(self, reply_all: bool = False):
+        partners = self.env["res.partner"].find_or_create(self.email_from)
+        if reply_all:
+            partners = (partners | self.partner_ids) - self.env.user.partner_id
+        return partners.ids
 
-    def reply_message(self):
+    def reply_message(self, reply_all: bool = False):
         action = self.env["ir.actions.actions"]._for_xml_id(
             "mail.action_email_compose_message_wizard"
         )
@@ -58,7 +61,7 @@ class MailMessage(models.Model):
             "is_quoted_reply": True,
             "default_notify": True,
             "force_email": True,
-            "default_partner_ids": self._default_reply_partner(),
+            "default_partner_ids": self._default_reply_partner(reply_all=reply_all),
         }
 
         # If the original message had a subject, we use it as a base for the

--- a/mail_quoted_reply/static/src/message_actions.esm.js
+++ b/mail_quoted_reply/static/src/message_actions.esm.js
@@ -6,3 +6,10 @@ messageActionsRegistry.add("reply", {
     onClick: (component) => component.message.messageReply(component.props.message),
     condition: (component) => component.canReply,
 });
+messageActionsRegistry.add("reply_all", {
+    icon: "fa fa-reply-all",
+    title: "Reply All",
+    onClick: (component) =>
+        component.message.messageReply(component.props.message, true),
+    condition: (component) => component.canReply,
+});

--- a/mail_quoted_reply/static/src/message_model.esm.js
+++ b/mail_quoted_reply/static/src/message_model.esm.js
@@ -2,11 +2,11 @@ import {Message} from "@mail/core/common/message_model";
 import {patch} from "@web/core/utils/patch";
 
 patch(Message.prototype, {
-    async messageReply(message) {
+    async messageReply(message, reply_all = false) {
         var self = this;
         const thread = message.thread;
         await this.store.env.services.orm
-            .call("mail.message", "reply_message", [message.id])
+            .call("mail.message", "reply_message", [message.id, reply_all])
             .then(function (result) {
                 return self.store.env.services.action.doAction(result, {
                     onClose: async () => {

--- a/mail_quoted_reply/tests/test_reply.py
+++ b/mail_quoted_reply/tests/test_reply.py
@@ -44,3 +44,56 @@ class TestMessageReply(TransactionCase):
         )
         self.assertTrue(new_message)
         self.assertEqual(1, len(new_message))
+
+    def test_reply_all(self):
+        partner_demo = self.env["res.partner"].create({"name": "demo partner"})
+        partner_sender = self.env["res.partner"].create(
+            {"name": "sender partner", "email": "test@mail.com"}
+        )
+        self.assertFalse(
+            partner_demo.message_ids.filtered(
+                lambda r: r.message_type != "notification"
+            )
+        )
+        self.assertFalse(
+            partner_sender.message_ids.filtered(
+                lambda r: r.message_type != "notification"
+            )
+        )
+        # pylint: disable=C8107
+        recipient = self.env.ref("base.partner_demo")
+        message = partner_demo.message_post(
+            body="demo message",
+            message_type="email",
+            partner_ids=recipient.ids,
+            author_id=partner_sender.id,
+        )
+        partner_demo.invalidate_recordset()
+        self.assertIn(
+            message,
+            partner_demo.message_ids.filtered(
+                lambda r: r.message_type != "notification"
+            ),
+        )
+        self.assertFalse(
+            partner_demo.message_ids.filtered(
+                lambda r: r.message_type != "notification" and r != message
+            )
+        )
+        action = message.reply_message(reply_all=True)
+        wizard = (
+            self.env[action["res_model"]].with_context(**action["context"]).create({})
+        )
+        self.assertTrue(wizard.partner_ids)
+        expected_partners = partner_sender | recipient
+        self.assertEqual(expected_partners, wizard.partner_ids)
+        # the onchange in the composer isn't triggered in tests, so we check for the
+        # correct quote in the context
+        email_quote = re.search("<p>.*?</p>", wizard._context["quote_body"]).group()
+        self.assertEqual("<p>demo message</p>", email_quote)
+        wizard.action_send_mail()
+        new_message = partner_demo.message_ids.filtered(
+            lambda r: r.message_type != "notification" and r != message
+        )
+        self.assertTrue(new_message)
+        self.assertEqual(1, len(new_message))


### PR DESCRIPTION
Add a reply to all button to messages. Default partners is the sender and all recipients of the original message without the user sending it.

Based on PR https://github.com/OCA/social/pull/1688