### PR TITLE
[18.0][FIX]mail_quoted_reply: unintentional tags

### DIFF
--- a/mail_quoted_reply/models/mail_message.py
+++ b/mail_quoted_reply/models/mail_message.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, models
-from odoo.tools import format_datetime, html_sanitize
+from odoo.tools import format_datetime, html_escape, html_sanitize
 
 
 class MailMessage(models.Model):
@@ -31,9 +31,9 @@ class MailMessage(models.Model):
             </blockquote>
             </div>
         """.format(
-            email_from=self.email_from,
+            email_from=html_escape(self.email_from),
             date=format_datetime(self.env, self.date),
-            subject=self.subject,
+            subject=html_escape(self.subject),
             body=self._get_sanitized_body(),
             signature=self.env.user.signature,
             str_date=_("Date"),

--- a/mail_quoted_reply/tests/test_reply.py
+++ b/mail_quoted_reply/tests/test_reply.py
@@ -29,6 +29,12 @@ class TestMessageReply(TransactionCase):
             )
         )
         action = message.reply_message()
+
+        quote_body = action.get("context", {}).get("quote_body", "")
+        self.assertTrue(
+            "From: &#34;OdooBot&#34; &lt;odoobot@example.com&gt;" in quote_body
+        )
+
         wizard = (
             self.env[action["res_model"]].with_context(**action["context"]).create({})
         )


### PR DESCRIPTION
<...> text of subject and from in the quoted reply block are interpreted as tags and thus not shown in the composer. The unintentional tag may lead to browser problems because the browser sees it as an opening tag without a closing one.

### Steps to reproduce
Reply to any message. The composer will open and from field at the reply will only show the name and not the e-mail address. Inspecting with the developer tools of the browser shows that the e-mail address is interpreted as a tag. The same behavior can be observed for the subject for the reply (in the quoted reply block)

Port of  https://github.com/OCA/social/pull/1435
