### PR TITLE
[18.0] [FIX] mail_tracking: missing onUpdate prop

### DIFF
--- a/mail_tracking/static/src/components/failed_message/failed_message.esm.js
+++ b/mail_tracking/static/src/components/failed_message/failed_message.esm.js
@@ -8,7 +8,7 @@ import {useService} from "@web/core/utils/hooks";
 import {Component, toRaw, useState} from "@odoo/owl";
 
 export class FailedMessage extends Component {
-    static props = ["message", "reloadParentView"];
+    static props = ["message", "onUpdate?", "reloadParentView"];
     // eslint-disable-next-line no-empty-function
     static defaultProps = {onUpdate: () => {}};
     static template = "mail_tracking.FailedMessage";


### PR DESCRIPTION
This prop was removed during the migration to 18.0 (974b492f), probably by mistake, and yet causing this regression.

The `onUpdate` prop is used here:
https://github.com/OCA/mail/blob/b0226505/mail_tracking/static/src/core/chatter/chatter.xml#L34

And so the UI breaks whene trying to render a thread that contains failed messages.

Traceback:

```
UncaughtPromiseError > OwlError
Uncaught Promise > Invalid props for component 'FailedMessage': unknown key 'onUpdate'
Occured on localhost:8069 on 2025-09-04 17:57:30 GMT
OwlError: Invalid props for component 'FailedMessage': unknown key 'onUpdate'
    Error: Invalid props for component 'FailedMessage': unknown key 'onUpdate'
        at Object.validateProps (http://localhost:8069/web/assets/debug/web.assets_web.js:11207:19) (/web/static/lib/owl/owl.js:3214)
        at Chatter.template (eval at compile (http://localhost:8069/web/assets/debug/web.assets_web.js:13754:20), <anonymous>:30:17) (/web/static/lib/owl/owl.js:5761)
        at Chatter.template (eval at compile (http://localhost:8069/web/assets/debug/web.assets_web.js:13754:20), <anonymous>:194:30) (/web/static/lib/owl/owl.js:5761)
        at Fiber._render (http://localhost:8069/web/assets/debug/web.assets_web.js:9776:38) (/web/static/lib/owl/owl.js:1783)
        at Fiber.render (http://localhost:8069/web/assets/debug/web.assets_web.js:9768:18) (/web/static/lib/owl/owl.js:1775)
        at ComponentNode.updateAndRender (http://localhost:8069/web/assets/debug/web.assets_web.js:10564:19) (/web/static/lib/owl/owl.js:2571)
```