### PR TITLE
[18.0][FIX] mail_drop_target: Drop cryptography<37 requirement

### DIFF
--- a/mail_drop_target/__manifest__.py
+++ b/mail_drop_target/__manifest__.py
@@ -9,7 +9,7 @@
     "website": "https://github.com/OCA/mail",
     "summary": "Attach emails to Odoo by dragging them from your desktop",
     "depends": ["mail"],
-    "external_dependencies": {"python": ["extract_msg", "cryptography<37"]},
+    "external_dependencies": {"python": ["extract_msg"]},
     "data": ["views/res_config_settings_views.xml"],
     "assets": {
         "web.assets_backend": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # generated from manifests external_dependencies
-cryptography<37
 extract_msg
 premailer

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,3 @@
+cryptography==3.4.8
+pyopenssl==21.0.0
 odoo_test_helper


### PR DESCRIPTION
Currently including OCA/mail breaks all Odoo.sh builds, due to an unnecessary cryptography<37 requirement, which seems no longer relevant.

Fixes issue #81.