### PR TITLE
[FIX] mail_tracking_mailgun: DeprecationWarning: datetime.datetime.utcfromtimestamp()

### DIFF
--- a/mail_tracking_mailgun/models/mail_tracking_email.py
+++ b/mail_tracking_mailgun/models/mail_tracking_email.py
@@ -5,7 +5,7 @@
 
 import logging
 from collections import namedtuple
-from datetime import datetime
+from datetime import datetime, UTC
 from urllib.parse import urljoin
 
 import requests
@@ -103,7 +103,7 @@ class MailTrackingEmail(models.Model):
         except Exception:
             ts = False
         if ts:
-            dt = datetime.utcfromtimestamp(ts)
+            dt = datetime.fromtimestamp(ts, UTC)
             metadata.update(
                 {
                     "timestamp": ts,


### PR DESCRIPTION
DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).