### PR TITLE
[18.0][FIX] mail_tracking: ACL verification

### DIFF
--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -231,23 +231,28 @@ class MailTrackingEmail(models.Model):
             )
         )
         result = self.env.cr.fetchall()
-        for id_, mail_msg_id, mail_id, partner_id in result:
-            msg_ids = (
-                self.env["mail.message"].search([("id", "=", mail_msg_id)]).ids
-                if mail_msg_id
-                else []
-            )
+        _, msg_ids, mail_ids, partner_ids = zip(*result, strict=True)
+        msg_ids = (
+            self.env["mail.message"]
+            .search([("id", "in", [x for x in msg_ids if x])])
+            .ids
+        )
+        # Only users from group_system can read mail.mail
+        if self.env.user.has_group("base.group_system"):
             mail_ids = (
-                self.env["mail.mail"].search([("id", "=", mail_id)]).ids
-                if mail_id
-                else []
+                self.env["mail.mail"]
+                .search([("id", "in", [x for x in mail_ids if x])])
+                .ids
             )
-            partner_ids = (
-                self.env["res.partner"].search([("id", "=", partner_id)]).ids
-                if partner_id
-                else []
-            )
+        else:
+            mail_ids = []
+        partner_ids = (
+            self.env["res.partner"]
+            .search([("id", "in", [x for x in partner_ids if x])])
+            .ids
+        )
 
+        for id_, mail_msg_id, mail_id, partner_id in result:
             if (
                 (mail_msg_id in msg_ids)
                 or (mail_id in mail_ids)


### PR DESCRIPTION
The current method for checking ACL is very slow since for each mail.tracking.email object it would search for corresponding mail.tracking.email, mail.mail and res.partner linked objects.

In order to improve performance, we search for these objects once and use the lists we get to determine to which mail.tracking.email the user should have access (like it was done before refactoring for v18 during migration in https://github.com/OCA/mail/pull/1/commits/974b492fe527c202c002789157a44e6978db70f3#diff-5857f6442d6d80127ae610d9e67dbd61233656bfe0b095e0bd55efb3f75e71b4)

Also, since we are looking for mail.mail objects, which are only accessible for users in group_system, it only worked for users in this group. I also added a if to search mail.mail only if user is in group_system, allowing users which are not in that group to still access mail.tracking.email.

On my database with 7000 mail.tracking.email objects, I get the following performance gain (calculated with %timeit in shell) :

- With admin user (access to 6924 records) :
  - Before this PR = 27.5 s
  - With this PR = 809 ms

- With non admin user  (access to 1173 records) :
  - Before this PR = 30.8 s (with a tweak to no search for mail.mail objects otherwise AccessError)
  - With this PR = 154 ms 