### PR TITLE
[18.0][FIX] base_search_mail_content: Error `a bytes-like object is required, not 'str'`

### DIFF
--- a/base_search_mail_content/models/mail_thread.py
+++ b/base_search_mail_content/models/mail_thread.py
@@ -56,5 +56,5 @@ class MailThread(models.AbstractModel):
                     "field", {"name": "message_content", "operator": "%"}
                 )
                 node.addnext(elem)
-                res["arch"] = etree.tostring(doc)
+                res["arch"] = etree.tostring(doc, encoding="unicode")
         return res


### PR DESCRIPTION
When use module with [`l10n_es_partner`](https://github.com/OCA/l10n-spain/tree/18.0/l10n_es_partner), an error happens

```
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 2166, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 156, in retrying
    result = func()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 2133, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 2381, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 333, in _dispatch
    result = endpoint(**request.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/auto/addons/web/controllers/dataset.py", line 36, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 535, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "/opt/odoo/auto/addons/l10n_es_partner/models/res_partner.py", line 64, in get_views
    res["views"]["search"]["arch"] = res["views"]["search"]["arch"].replace(
TypeError: a bytes-like object is required, not 'str'
```

@Shide @yajo @pedrobaeza @carlos-lopez-tecnativa can you review, please? Thank you.

MT-12387 @moduon