### PR TITLE
[18.0][FIX] mail_message_search: Error a bytes-like object is required, not str

### DIFF
--- a/mail_message_search/models/mail_thread.py
+++ b/mail_message_search/models/mail_thread.py
@@ -56,5 +56,5 @@ class MailThread(models.AbstractModel):
                 # Add message_search in search view
                 elem = etree.Element("field", {"name": "message_search"})
                 node.addnext(elem)
-                res["arch"] = etree.tostring(doc)
+                res["arch"] = etree.tostring(doc, encoding="unicode")
         return res


### PR DESCRIPTION
This module causes the same issue with https://github.com/OCA/mail/pull/102#issue-3562387721 if we don't have `encoding`.

@qrtl QT5667