### PR TITLE
[18.0][FIX] mail_tracking: Prevent error when the SQL result is empty.

### DIFF
--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -231,7 +231,9 @@ class MailTrackingEmail(models.Model):
             )
         )
         result = self.env.cr.fetchall()
-        _, msg_ids, mail_ids, partner_ids = zip(*result, strict=True)
+        msg_ids, mail_ids, partner_ids = [], [], []
+        if result:
+            _, msg_ids, mail_ids, partner_ids = zip(*result, strict=True)
         msg_ids = (
             self.env["mail.message"]
             .search([("id", "in", [x for x in msg_ids if x])])


### PR DESCRIPTION
Before this commit, when the user clicked on the icon of a message, the following error occurred: `ValueError: not enough values to unpack (expected 4, got 0)`

Complementary to 86e188c1599638071621f850a0fe875afedd851c

<img width="1425" height="919" alt="image" src="https://github.com/user-attachments/assets/56a649bc-9965-4459-b206-11fd3f919922" />

TT59417
@Tecnativa @pedrobaeza @carlosdauden @sergio-teruel  @remi-filament could you please review this? 