### PR TITLE
[18.0][FIX]mail_quoted_reply:automatically load message

### DIFF
--- a/mail_quoted_reply/static/src/message_model.esm.js
+++ b/mail_quoted_reply/static/src/message_model.esm.js
@@ -15,6 +15,7 @@ patch(Message.prototype, {
                             ["messages"]
                         );
                         self.store.env.bus.trigger("update-messages");
+                        await thread?.fetchNewMessages();
                     },
                 });
             });


### PR DESCRIPTION
After sending a reply, the site needs to be reloaded manually to see the sent message.

**Steps to reproduce**
1. Open any chatter with a message
2. reply to a message
3. Click send

**Expected behavior**
The sent message is shown in the chatter

**Actual behavior**
The site needs to be reloaded manually before the sent message is shown in the chatter