### PR TITLE
[18.0][FIX] mail_tracking: Error on tabs without thread open when marking as reviewed

### DIFF
--- a/mail_tracking/static/src/services/mail_core_common_service_patch.esm.js
+++ b/mail_tracking/static/src/services/mail_core_common_service_patch.esm.js
@@ -11,6 +11,7 @@ patch(MailCoreCommon.prototype, {
                 const {message_ids: messageIds} = payload;
                 for (const id of messageIds) {
                     const message = this.store.Message.get({id});
+                    if (!message) continue;
                     const failedBox = this.store.failed;
                     if (notifId > failedBox.counter_bus_id) {
                         failedBox.counter--;


### PR DESCRIPTION
Before these changes, when the bus event was received in tabs that did not have the message open, an error appeared because the system was not able to find the message.

After these changes, if the message is not available on the screen, the process continues because synchronization will not be necessary, and therefore the error will no longer occur.

cc @Tecnativa

ping @pedrobaeza @carlos-lopez-tecnativa 