### PR TITLE
[18.0][FIX] mail_show_follower: handle case where record no longer ex…

### DIFF
--- a/mail_show_follower/models/mail_mail.py
+++ b/mail_show_follower/models/mail_mail.py
@@ -80,6 +80,8 @@ class MailMail(models.Model):
             # recipients from any Notification Type (i.e. email, inbox, etc.)
             recipients = mail.notification_ids.res_partner_id
             record = self.env[mail.model].browse(mail.res_id)
+            if not record.exists():
+                continue
             company = getattr(record, "company_id", False)
             if not company:
                 company = self.env.company


### PR DESCRIPTION
…ists

In the case where the original record from the mail has been deleted, attempting to access any value on it raises:

MissingError: Record does not exist or has been deleted

As a simple solution, this fix skips the module's functionality when the record no longer exists. A more complete solution would be to personalize the message body somewhere upstream, however that would require more changes in the way the module is structured. As of now, this fix seems sufficient for exceptional cases.