### PR TITLE
[18.0][IMP] mail_restrict_follower_selection: enhance domain filtering forfollower selection

### DIFF
--- a/mail_restrict_follower_selection/README.rst
+++ b/mail_restrict_follower_selection/README.rst
@@ -52,9 +52,15 @@ certain record type (or have different restrictions for different record
 types), create a parameter
 mail_restrict_follower_selection.domain.$your_model.
 
-As an example, you could use [('category_id.name', '=', 'Employees')] to
-allow only contacts with 'Employees' tag to be added as follower - this
-also is the default.
+Some examples:
+
+-  ``[("category_id.name", "=", "Employees")]`` : Only allow contacts
+   with 'Employees' tag
+-  ``[("is_company", "=", False)]`` : Restrict company contacts to be
+   added as follower (to avoid emails to info@ email address)
+-  ``[("user_ids","!=",False)]`` : Restrict to contacts with user
+   (internal and portal)
+-  ``[("employee_ids","!=",False)]`` : Restrict to employees
 
 Note: This module won't change existing followers!
 

--- a/mail_restrict_follower_selection/data/ir_config_parameter.xml
+++ b/mail_restrict_follower_selection/data/ir_config_parameter.xml
@@ -2,6 +2,6 @@
 <odoo noupdate="1">
     <record forcecreate="False" id="parameter_domain" model="ir.config_parameter">
         <field name="key">mail_restrict_follower_selection.domain</field>
-        <field name="value">[('category_id.name', '=', 'Employees')]</field>
+        <field name="value">[]</field>
     </record>
 </odoo>

--- a/mail_restrict_follower_selection/models/mail_thread.py
+++ b/mail_restrict_follower_selection/models/mail_thread.py
@@ -1,4 +1,4 @@
-from odoo import models
+from odoo import fields, models
 from odoo.tools import config
 from odoo.tools.safe_eval import safe_eval
 
@@ -7,6 +7,12 @@ from ..utils import _id_get
 
 class MailThread(models.AbstractModel):
     _inherit = "mail.thread"
+
+    message_partner_ids = fields.Many2many(
+        domain=lambda thread: thread.env[
+            "mail.wizard.invite"
+        ]._mail_restrict_follower_selection_get_domain(thread._name)
+    )
 
     def _message_add_suggested_recipient(
         self, result, partner=None, email=None, lang=None, reason=""

--- a/mail_restrict_follower_selection/readme/CONFIGURE.md
+++ b/mail_restrict_follower_selection/readme/CONFIGURE.md
@@ -5,8 +5,11 @@ certain record type (or have different restrictions for different record
 types), create a parameter
 mail_restrict_follower_selection.domain.\$your_model.
 
-As an example, you could use \[('category_id.name', '=', 'Employees')\]
-to allow only contacts with 'Employees' tag to be added as follower -
-this also is the default.
+Some examples:
+
+- `[("category_id.name", "=", "Employees")]` : Only allow contacts with 'Employees' tag
+- `[("is_company", "=", False)]` : Restrict company contacts to be added as follower (to avoid emails to info@ email address)
+- `[("user_ids","!=",False)]` : Restrict to contacts with user (internal and portal)
+- `[("employee_ids","!=",False)]` : Restrict to employees
 
 Note: This module won't change existing followers!

--- a/mail_restrict_follower_selection/static/description/index.html
+++ b/mail_restrict_follower_selection/static/description/index.html
@@ -398,9 +398,16 @@ followers globally, if you want to restrict only the followers for a
 certain record type (or have different restrictions for different record
 types), create a parameter
 mail_restrict_follower_selection.domain.$your_model.</p>
-<p>As an example, you could use [(‘category_id.name’, ‘=’, ‘Employees’)] to
-allow only contacts with ‘Employees’ tag to be added as follower - this
-also is the default.</p>
+<p>Some examples:</p>
+<ul class="simple">
+<li><tt class="docutils literal"><span class="pre">[(&quot;category_id.name&quot;,</span> <span class="pre">&quot;=&quot;,</span> <span class="pre">&quot;Employees&quot;)]</span></tt> : Only allow contacts
+with ‘Employees’ tag</li>
+<li><tt class="docutils literal"><span class="pre">[(&quot;is_company&quot;,</span> <span class="pre">&quot;=&quot;,</span> False)]</tt> : Restrict company contacts to be
+added as follower (to avoid emails to info&#64; email address)</li>
+<li><tt class="docutils literal"><span class="pre">[(&quot;user_ids&quot;,&quot;!=&quot;,False)]</span></tt> : Restrict to contacts with user
+(internal and portal)</li>
+<li><tt class="docutils literal"><span class="pre">[(&quot;employee_ids&quot;,&quot;!=&quot;,False)]</span></tt> : Restrict to employees</li>
+</ul>
 <p>Note: This module won’t change existing followers!</p>
 </div>
 <div class="section" id="bug-tracker">


### PR DESCRIPTION
1) I don't think that filtering on employees in default is a good setup. After installation of the module, the default behavior should not be changed.

2) There were dialogs, where the filter did not work in the search, but restricted/removed it on save. After save it looked like it was added, but after a page reload the new follower was not there. 
This occurs in the enterprise helpdesk team form.

<img width="471" height="121" alt="image" src="https://github.com/user-attachments/assets/f5434a1e-742e-47f9-b4f8-fef10d0ae077" />
