### PR TITLE
[FIX] mail_debrand: debrand notification emails after Odoo layout change

### DIFF
--- a/mail_debrand/README.rst
+++ b/mail_debrand/README.rst
@@ -101,6 +101,7 @@ Contributors
   - João Marques
 
 - Stefan Rijnhart stefan@opener.amsterdam
+- Jord Duineveld jord.duineveld@codeforward.nl
 
 Maintainers
 -----------

--- a/mail_debrand/__manifest__.py
+++ b/mail_debrand/__manifest__.py
@@ -12,7 +12,7 @@
     ( for powerd by) form all the templates
     removes any 'odoo' that are in tempalte texts > 20characters
     """,
-    "version": "18.0.1.0.1",
+    "version": "18.0.1.0.2",
     "category": "Social Network",
     "website": "https://github.com/OCA/mail",
     "author": """Tecnativa, ForgeFlow, Onestein, Sodexis, Nexterp Romania,

--- a/mail_debrand/models/__init__.py
+++ b/mail_debrand/models/__init__.py
@@ -1,2 +1,3 @@
-from . import mail_render_mixin
 from . import mail_mail
+from . import mail_render_mixin
+from . import mail_thread

--- a/mail_debrand/models/mail_render_mixin.py
+++ b/mail_debrand/models/mail_render_mixin.py
@@ -41,10 +41,14 @@ class MailRenderMixin(models.AbstractModel):
                 # Remove "Powered by", "using" etc.
                 previous = elem.getprevious()
                 if previous is not None:
-                    previous.tail = etree.CDATA("&nbsp;")
+                    previous.tail = None
                 elif parent.text:
-                    parent.text = etree.CDATA("&nbsp;")
+                    parent.text = None
                 parent.remove(elem)
+            # Clean up dangling pipe separator in unfollow span
+            for span in tree.xpath('//span[@id="mail_unfollow"]'):
+                if span.text and "|" in span.text:
+                    span.text = None
             value = etree.tostring(
                 tree, pretty_print=True, method="html", encoding="unicode"
             )

--- a/mail_debrand/models/mail_thread.py
+++ b/mail_debrand/models/mail_thread.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Codeforward B.V. - Jord Duineveld
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import models
+
+
+class MailThread(models.AbstractModel):
+    _inherit = "mail.thread"
+
+    def _notify_by_email_render_layout(
+        self, message, recipients_group, msg_vals=False, render_values=None
+    ):
+        mail_body = super()._notify_by_email_render_layout(
+            message, recipients_group, msg_vals=msg_vals, render_values=render_values
+        )
+        return self.env["mail.render.mixin"].remove_href_odoo(mail_body or "")

--- a/mail_debrand/readme/CONTRIBUTORS.md
+++ b/mail_debrand/readme/CONTRIBUTORS.md
@@ -4,3 +4,4 @@
     -   Pedro M. Baeza
     -   João Marques
 - Stefan Rijnhart <stefan@opener.amsterdam>
+- Jord Duineveld <jord.duineveld@codeforward.nl>

--- a/mail_debrand/static/description/index.html
+++ b/mail_debrand/static/description/index.html
@@ -456,6 +456,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </li>
 <li>Stefan Rijnhart <a class="reference external" href="mailto:stefan&#64;opener.amsterdam">stefan&#64;opener.amsterdam</a></li>
+<li>Jord Duineveld <a class="reference external" href="mailto:jord.duineveld&#64;codeforward.nl">jord.duineveld&#64;codeforward.nl</a></li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Odoo commit 9f65f1a introduced conditional footer rendering in mail_notification_layout, but mail_debrand only hooked into _render_template (which notification emails bypass via ir.qweb._render) and _prepare_outgoing_body.

Add _notify_by_email_render_layout override on mail.thread to catch branding at the actual render point for all notification emails.

Also clean up leftover pipe separator and whitespace from the unfollow span after removing the Odoo branding link.