### PR TITLE
[18.0][REF] mail_post_defer: adapt to upstream API change in assertNoMail

### DIFF
--- a/mail_post_defer/tests/test_mail.py
+++ b/mail_post_defer/tests/test_mail.py
@@ -40,7 +40,9 @@ class MessagePostCase(MailPostDeferCommon):
                 ]
             )
             self.assertEqual(len(schedules), 1)
-            self.assertNoMail(self.partner_employee)
+            self.assertNoMail(
+                self.partner_employee, mail_message=self.env["mail.message"]
+            )
 
     def test_forced_arg(self):
         """A forced send via method argument is sent directly."""
@@ -98,7 +100,9 @@ class MessagePostCase(MailPostDeferCommon):
                 ]
             )
             self.assertEqual(len(schedules), 1)
-            self.assertNoMail(self.partner_employee)
+            self.assertNoMail(
+                self.partner_employee, mail_message=self.env["mail.message"]
+            )
             # After 15 seconds, the user updates the message
             with freezegun.freeze_time("2023-01-02 10:00:15"):
                 self.partner_portal._message_update_content(msg, "new body")
@@ -109,7 +113,9 @@ class MessagePostCase(MailPostDeferCommon):
                     ]
                 )
                 self.assertEqual(len(schedules), 1)
-                self.assertNoMail(self.partner_employee)
+                self.assertNoMail(
+                    self.partner_employee, mail_message=self.env["mail.message"]
+                )
             # After a minute, the mail is created
             with freezegun.freeze_time("2023-01-02 10:01:00"):
                 self.env["mail.message.schedule"]._send_notifications_cron()
@@ -145,6 +151,7 @@ class MessagePostCase(MailPostDeferCommon):
             self.assertNoMail(
                 self.partner_employee,
                 author=self.env.user.partner_id,
+                mail_message=self.env["mail.message"],
             )
             # One minute later, the cron has no mails to send
             with freezegun.freeze_time("2023-01-02 10:01:00"):
@@ -153,6 +160,7 @@ class MessagePostCase(MailPostDeferCommon):
                 self.assertNoMail(
                     self.partner_employee,
                     author=self.env.user.partner_id,
+                    mail_message=self.env["mail.message"],
                 )
 
     def test_no_sent_msg_delete(self):
@@ -210,7 +218,10 @@ class MessagePostCase(MailPostDeferCommon):
                 partner_ids=(self.partner_employee | self.partner_portal).ids,
                 res_id=self.ref("base.es"),
             )
-            self.assertNoMail(self.partner_employee | self.partner_portal)
+            self.assertNoMail(
+                self.partner_employee | self.partner_portal,
+                mail_message=self.env["mail.message"],
+            )
             # One minute later, the cron sends the mail
             with freezegun.freeze_time("2023-01-02 10:01:00"):
                 self.env["mail.message.schedule"]._send_notifications_cron()
@@ -223,7 +234,9 @@ class MessagePostCase(MailPostDeferCommon):
                 )
                 # res.partner does not send mail because res.country does not inherit
                 # from mail.thread
-                self.assertNoMail(self.partner_employee)
+                self.assertNoMail(
+                    self.partner_employee, mail_message=self.env["mail.message"]
+                )
         # Safety belt to avoid false positives in this test
         self.assertFalse(hasattr(self.env["res.country"], "_notify_thread"))
         self.assertTrue(hasattr(self.env["res.partner"], "_notify_thread"))
@@ -240,7 +253,9 @@ class MessagePostCase(MailPostDeferCommon):
                 message_type="comment",
                 partner_ids=(self.partner_employee | customer).ids,
             )
-            self.assertNoMail(self.partner_employee | customer)
+            self.assertNoMail(
+                self.partner_employee | customer, mail_message=self.env["mail.message"]
+            )
             # After a minute, mails are sent
             with freezegun.freeze_time("2023-01-02 10:01:00"):
                 self.env["mail.message.schedule"]._send_notifications_cron()
@@ -303,7 +318,9 @@ class ComposerCase(MailPostDeferCommon):
                 ]
             )
             self.assertEqual(len(schedules), 1)
-            self.assertNoMail(self.partner_employee)
+            self.assertNoMail(
+                self.partner_employee, mail_message=self.env["mail.message"]
+            )
             with freezegun.freeze_time("2023-01-02 10:01:00"):
                 self.env["mail.message.schedule"]._send_notifications_cron()
                 self.env["mail.mail"].process_email_queue()
@@ -328,7 +345,9 @@ class AutomaticNotificationCase(MailPostDeferCommon):
         with self.mock_mail_gateway():
             self.partner_portal.user_id = self.user_employee.id
             self.partner_portal.flush_recordset()
-            self.assertNoMail(self.partner_employee)
+            self.assertNoMail(
+                self.partner_employee, mail_message=self.env["mail.message"]
+            )
             schedules = self.env["mail.message.schedule"].search(
                 [
                     ("mail_message_id.res_id", "=", self.partner_portal.id),


### PR DESCRIPTION
Fixes

```
2023-01-02 10:00:00,000 347 ERROR odoo odoo.addons.mail_post_defer.tests.test_mail: ERROR: MessagePostCase.test_model_without_threading
Traceback (most recent call last):
  File "/__w/mail/mail/mail_post_defer/tests/test_mail.py", line 213, in test_model_without_threading
    self.assertNoMail(self.partner_employee | self.partner_portal)
  File "/opt/odoo/addons/mail/tests/common.py", line 753, in assertNoMail
    self.assertNotSentEmail(recipients=recipients, message_id=mail_message.message_id)
AttributeError: 'NoneType' object has no attribute 'message_id'
```

Regression of https://github.com/odoo/odoo/pull/230766, fix proposed in https://github.com/odoo/odoo/pull/255720.