### PR TITLE
[18.0][FIX] mail_activity_team: enhance _get_default_team_id method to handle user and model IDs

### DIFF
--- a/mail_activity_team/models/mail_activity.py
+++ b/mail_activity_team/models/mail_activity.py
@@ -8,23 +8,28 @@ from odoo.exceptions import ValidationError
 class MailActivity(models.Model):
     _inherit = "mail.activity"
 
-    def _get_default_team_id(self):
-        self.ensure_one()
+    def _get_default_team_id(self, user_id=None, model_id=None):
+        if not user_id:
+            user_id = self.user_id.id or self.env.user.id
+        if not model_id:
+            model_id = self.res_model_id.id if self.res_model_id else None
         domain = []
-        domain.append(("member_ids", "=", self.user_id.id or self.env.user.id))
-        if self.res_model_id:
+        domain.append(("member_ids", "=", user_id))
+        if model_id:
             domain += [
                 "|",
                 ("res_model_ids", "=", False),
-                ("res_model_ids", "=", self.res_model_id.id),
+                ("res_model_ids", "=", model_id),
             ]
         if not domain:
             return self.env["mail.activity.team"]
         teams = self.env["mail.activity.team"].search(domain)
-        if self.res_model_id:
+        if model_id:
             # Prefer teams with a matching model
             teams = (
-                teams.filtered(lambda mat: self.res_model_id in mat.res_model_ids)
+                teams.filtered(
+                    lambda mat, model_id=model_id: model_id in mat.res_model_ids.ids
+                )
                 or teams
             )
         return teams[:1]
@@ -56,7 +61,9 @@ class MailActivity(models.Model):
                     and activity.res_model_id not in activity.team_id.res_model_ids
                 )
             ):
-                activity.team_id = activity._get_default_team_id()
+                activity.team_id = activity._get_default_team_id(
+                    activity.user_id.id, activity.res_model_id.id
+                )
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/mail_activity_team/tests/test_mail_activity_team.py
+++ b/mail_activity_team/tests/test_mail_activity_team.py
@@ -116,6 +116,21 @@ class TestMailActivityTeam(TransactionCase):
                 }
             )
         )
+        cls.schedule_act2 = (
+            cls.env["mail.activity.schedule"]
+            .with_user(cls.employee)
+            .with_context(
+                active_model=cls.partner_client._name,
+                active_ids=cls.partner_client.ids,
+                default_activity_user_id=cls.employee.id,
+            )
+            .create(
+                {
+                    "activity_type_id": cls.activity2.id,
+                    "note": "Partner activity 2.",
+                }
+            )
+        )
 
     def test_activity_members(self):
         self.team1.member_ids |= self.employee2
@@ -223,6 +238,100 @@ class TestMailActivityTeam(TransactionCase):
         with Form(self.act2) as form:
             form.activity_type_id = self.activity1
             self.assertEqual(form.team_id, self.team1)
+
+    ### Test mail.activity.schedule onchange / compute functionality, analogous
+    ### to the mail.activity tests above.
+    def test_schedule_activity_onchanges_keep_user(self):
+        self.assertEqual(
+            self.schedule_act2.activity_team_id,
+            self.team1,
+            "Error: wizard should have Team 1.",
+        )
+        with Form(self.schedule_act2) as form:
+            form.activity_team_id = self.env["mail.activity.team"]
+            self.assertEqual(form.activity_user_id, self.employee)
+
+    def test_schedule_activity_onchanges_user_no_member_team(self):
+        self.assertEqual(
+            self.schedule_act2.activity_team_id,
+            self.team1,
+            "Error: Activity 2 should have Team 1.",
+        )
+        with self.assertRaises(
+            AssertionError, msg="can't write on invisible field user_id"
+        ):
+            with Form(self.schedule_act2) as form:
+                form.activity_user_id = self.employee2
+
+    def test_schedule_activity_onchanges_user_no_team(self):
+        self.assertEqual(
+            self.schedule_act2.activity_team_id,
+            self.team1,
+            "Error: Activity 2 should have Team 1.",
+        )
+        with Form(self.schedule_act2) as form:
+            form.activity_team_id = self.env["mail.activity.team"]
+            form.activity_user_id = self.employee2
+            self.assertEqual(form.activity_team_id, self.team2)
+
+    def test_schedule_activity_onchanges_team_no_member(self):
+        self.assertEqual(
+            self.schedule_act2.activity_team_id,
+            self.team1,
+            "Error: Activity 2 should have Team 1.",
+        )
+        self.team2.user_id = False
+        self.team2.member_ids = False
+        with Form(self.schedule_act2) as form:
+            form.activity_team_id = self.team2
+            self.assertFalse(form.activity_user_id)
+
+    def test_schedule_activity_onchanges_team_different_member(self):
+        self.assertEqual(
+            self.schedule_act2.activity_team_id,
+            self.team1,
+            "Error: Activity 2 should have Team 1.",
+        )
+        self.team2.user_id = self.employee2
+        self.team2.member_ids = self.employee2
+        with Form(self.schedule_act2) as form:
+            form.activity_team_id = self.team2
+            self.assertEqual(form.activity_user_id, self.employee2)
+
+    def test_schedule_activity_onchanges_team_different_member_no_leader(self):
+        self.assertEqual(
+            self.schedule_act2.activity_team_id,
+            self.team1,
+            "Error: Activity 2 should have Team 1.",
+        )
+        self.team2.user_id = False
+        self.team2.member_ids = self.employee2
+        with Form(self.schedule_act2) as form:
+            form.activity_team_id = self.team2
+            self.assertEqual(form.activity_user_id, self.employee2)
+
+    def test_schedule_activity_onchanges_activity_type_set_team(self):
+        self.assertEqual(
+            self.schedule_act2.activity_team_id,
+            self.team1,
+            "Error: Activity 2 should have Team 1.",
+        )
+        self.activity1.default_team_id = self.team2
+        self.assertEqual(self.schedule_act2.activity_type_id, self.activity2)
+        with Form(self.schedule_act2) as form:
+            form.activity_type_id = self.activity1
+            self.assertEqual(form.activity_team_id, self.team2)
+
+    def test_schedule_activity_onchanges_activity_type_no_team(self):
+        self.assertEqual(
+            self.schedule_act2.activity_team_id,
+            self.team1,
+            "Error: Activity 2 should have Team 1.",
+        )
+        self.assertEqual(self.schedule_act2.activity_type_id, self.activity2)
+        with Form(self.schedule_act2) as form:
+            form.activity_type_id = self.activity1
+            self.assertEqual(form.activity_team_id, self.team1)
 
     def test_activity_constrain(self):
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
Introduced by: https://github.com/OCA/mail/pull/149
<img width="422" height="226" alt="image" src="https://github.com/user-attachments/assets/307df7a5-589d-460a-b7a0-54d7acee6da2" />


```

Odoo Server Error

RPC_ERROR
Odoo Server Error

Occured on oca-mail-18-0-88eec26a9337.runboat.odoo-community.org on model mail.activity.schedule on 2026-03-31 07:52:20 GMT

Traceback (most recent call last):
  File "/opt/odoo/odoo/http.py", line 2167, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "/opt/odoo/odoo/service/model.py", line 157, in retrying
    result = func()
  File "/opt/odoo/odoo/http.py", line 2134, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo/odoo/http.py", line 2382, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo/odoo/addons/base/models/ir_http.py", line 333, in _dispatch
    result = endpoint(**request.params)
  File "/opt/odoo/odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/addons/web/controllers/dataset.py", line 36, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/odoo/api.py", line 535, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "/opt/odoo/addons/web/models/models.py", line 1005, in onchange
    record._apply_onchange_methods(field_name, result)
  File "/opt/odoo/odoo/models.py", line 7386, in _apply_onchange_methods
    res = method(self)
  File "/mnt/data/odoo-addons-dir/mail_activity_team/wizard/mail_activity_schedule.py", line 53, in _onchange_activity_team_user_id
    and self.activity_team_user_id in self.activity_team_id.member_ids
  File "/opt/odoo/odoo/fields.py", line 3113, in __get__
    return super().__get__(records, owner)
  File "/opt/odoo/odoo/fields.py", line 1244, in __get__
    self.recompute(record)
  File "/opt/odoo/odoo/fields.py", line 1471, in recompute
    apply_except_missing(self.compute_value, recs)
  File "/opt/odoo/odoo/fields.py", line 1444, in apply_except_missing
    func(records)
  File "/opt/odoo/odoo/fields.py", line 1493, in compute_value
    records._compute_field_value(self)
  File "/opt/odoo/odoo/models.py", line 5302, in _compute_field_value
    fields.determine(field.compute, self)
  File "/opt/odoo/odoo/fields.py", line 110, in determine
    return needle(*args)
  File "/mnt/data/odoo-addons-dir/mail_activity_team/wizard/mail_activity_schedule.py", line 30, in _compute_activity_team_id
    ]._get_default_team_id(
TypeError: MailActivity._get_default_team_id() takes 1 positional argument but 3 were given

The above server error caused the following client error:
OwlError: An error occured in the owl lifecycle (see this Error's "cause" property)
    Error: An error occured in the owl lifecycle (see this Error's "cause" property)
        at handleError (http://oca-mail-18-0-88eec26a9337.runboat.odoo-community.org/web/assets/7de2c19/web.assets_web.min.js:972:101)
        at App.handleError (http://oca-mail-18-0-88eec26a9337.runboat.odoo-community.org/web/assets/7de2c19/web.assets_web.min.js:1631:29)
        at ComponentNode.initiateRender (http://oca-mail-18-0-88eec26a9337.runboat.odoo-community.org/web/assets/7de2c19/web.assets_web.min.js:1065:19)

Caused by: RPC_ERROR: Odoo Server Error
    RPC_ERROR
        at makeErrorFromResponse (http://oca-mail-18-0-88eec26a9337.runboat.odoo-community.org/web/assets/7de2c19/web.assets_web.min.js:3178:165)
        at XMLHttpRequest.<anonymous> (http://oca-mail-18-0-88eec26a9337.runboat.odoo-community.org/web/assets/7de2c19/web.assets_web.min.js:3184:13)
```