### PR TITLE
[18.0][FIX] mail_activity_team: remaining calls to previous refactored get_default_team_id method

### DIFF
--- a/mail_activity_team/tests/test_mail_activity_team.py
+++ b/mail_activity_team/tests/test_mail_activity_team.py
@@ -116,6 +116,21 @@ class TestMailActivityTeam(TransactionCase):
                 }
             )
         )
+        cls.schedule_act2 = (
+            cls.env["mail.activity.schedule"]
+            .with_user(cls.employee)
+            .with_context(
+                active_model=cls.partner_client._name,
+                active_ids=cls.partner_client.ids,
+                default_activity_user_id=cls.employee.id,
+            )
+            .create(
+                {
+                    "activity_type_id": cls.activity2.id,
+                    "note": "Partner activity 2.",
+                }
+            )
+        )
 
     def test_activity_members(self):
         self.team1.member_ids |= self.employee2
@@ -147,6 +162,9 @@ class TestMailActivityTeam(TransactionCase):
         self.team2.user_id = self.employee3
         self.team2._onchange_user_id()
         self.assertTrue(self.employee3 in self.team2.member_ids)
+
+    ### Test mail.activity onchange / compute functionality. Every test has
+    ### a counterpart below for mail.activity.schedule.
 
     def test_activity_onchanges_keep_user(self):
         self.assertEqual(
@@ -223,6 +241,101 @@ class TestMailActivityTeam(TransactionCase):
         with Form(self.act2) as form:
             form.activity_type_id = self.activity1
             self.assertEqual(form.team_id, self.team1)
+
+    ### Test mail.activity.schedule onchange / compute functionality, analogous
+    ### to the mail.activity tests above.
+
+    def test_schedule_activity_onchanges_keep_user(self):
+        self.assertEqual(
+            self.schedule_act2.activity_team_id,
+            self.team1,
+            "Error: wizard should have Team 1.",
+        )
+        with Form(self.schedule_act2) as form:
+            form.activity_team_id = self.env["mail.activity.team"]
+            self.assertEqual(form.activity_user_id, self.employee)
+
+    def test_schedule_activity_onchanges_user_no_member_team(self):
+        self.assertEqual(
+            self.schedule_act2.activity_team_id,
+            self.team1,
+            "Error: Activity 2 should have Team 1.",
+        )
+        with self.assertRaises(
+            AssertionError, msg="can't write on invisible field user_id"
+        ):
+            with Form(self.schedule_act2) as form:
+                form.activity_user_id = self.employee2
+
+    def test_schedule_activity_onchanges_user_no_team(self):
+        self.assertEqual(
+            self.schedule_act2.activity_team_id,
+            self.team1,
+            "Error: Activity 2 should have Team 1.",
+        )
+        with Form(self.schedule_act2) as form:
+            form.activity_team_id = self.env["mail.activity.team"]
+            form.activity_user_id = self.employee2
+            self.assertEqual(form.activity_team_id, self.team2)
+
+    def test_schedule_activity_onchanges_team_no_member(self):
+        self.assertEqual(
+            self.schedule_act2.activity_team_id,
+            self.team1,
+            "Error: Activity 2 should have Team 1.",
+        )
+        self.team2.user_id = False
+        self.team2.member_ids = False
+        with Form(self.schedule_act2) as form:
+            form.activity_team_id = self.team2
+            self.assertFalse(form.activity_user_id)
+
+    def test_schedule_activity_onchanges_team_different_member(self):
+        self.assertEqual(
+            self.schedule_act2.activity_team_id,
+            self.team1,
+            "Error: Activity 2 should have Team 1.",
+        )
+        self.team2.user_id = self.employee2
+        self.team2.member_ids = self.employee2
+        with Form(self.schedule_act2) as form:
+            form.activity_team_id = self.team2
+            self.assertEqual(form.activity_user_id, self.employee2)
+
+    def test_schedule_activity_onchanges_team_different_member_no_leader(self):
+        self.assertEqual(
+            self.schedule_act2.activity_team_id,
+            self.team1,
+            "Error: Activity 2 should have Team 1.",
+        )
+        self.team2.user_id = False
+        self.team2.member_ids = self.employee2
+        with Form(self.schedule_act2) as form:
+            form.activity_team_id = self.team2
+            self.assertEqual(form.activity_user_id, self.employee2)
+
+    def test_schedule_activity_onchanges_activity_type_set_team(self):
+        self.assertEqual(
+            self.schedule_act2.activity_team_id,
+            self.team1,
+            "Error: Activity 2 should have Team 1.",
+        )
+        self.activity1.default_team_id = self.team2
+        self.assertEqual(self.schedule_act2.activity_type_id, self.activity2)
+        with Form(self.schedule_act2) as form:
+            form.activity_type_id = self.activity1
+            self.assertEqual(form.activity_team_id, self.team2)
+
+    def test_schedule_activity_onchanges_activity_type_no_team(self):
+        self.assertEqual(
+            self.schedule_act2.activity_team_id,
+            self.team1,
+            "Error: Activity 2 should have Team 1.",
+        )
+        self.assertEqual(self.schedule_act2.activity_type_id, self.activity2)
+        with Form(self.schedule_act2) as form:
+            form.activity_type_id = self.activity1
+            self.assertEqual(form.activity_team_id, self.team1)
 
     def test_activity_constrain(self):
         with self.assertRaises(ValidationError):

--- a/mail_activity_team/wizard/mail_activity_schedule.py
+++ b/mail_activity_team/wizard/mail_activity_schedule.py
@@ -19,17 +19,28 @@ class MailActivitySchedule(models.TransientModel):
         readonly=False,
     )
 
-    @api.depends("activity_type_id")
+    @api.depends("res_model_id", "activity_user_id")
     def _compute_activity_team_id(self):
-        for scheduler in self:
-            if scheduler.activity_type_id.default_team_id:
-                scheduler.activity_team_id = scheduler.activity_type_id.default_team_id
-            elif not scheduler.activity_team_id:
-                scheduler.activity_team_id = self.env[
-                    "mail.activity"
-                ]._get_default_team_id(
-                    scheduler.activity_team_user_id.id, scheduler.sudo().res_model_id.id
+        """Assign team if no team yet or team is incompatible"""
+        for wizard in self:
+            if (
+                not wizard.activity_team_id
+                or wizard.activity_user_id
+                and wizard.activity_user_id not in wizard.activity_team_id.member_ids
+                or (
+                    wizard.res_model_id
+                    and wizard.activity_team_id.res_model_ids
+                    and wizard.res_model_id not in wizard.activity_team_id.res_model_ids
                 )
+            ):
+                # Reuse mail.activity default team logic
+                activity = self.env["mail.activity"].new(
+                    values={
+                        "res_model_id": wizard.sudo().res_model_id.id,
+                        "user_id": wizard.activity_user_id.id,
+                    },
+                )
+                wizard.activity_team_id = activity._get_default_team_id()
 
     @api.onchange("activity_team_id")
     def _onchange_activity_team_id(self):
@@ -46,16 +57,13 @@ class MailActivitySchedule(models.TransientModel):
             self.activity_team_user_id = new_user_id
             self.activity_user_id = new_user_id
 
-    @api.onchange("activity_team_user_id")
-    def _onchange_activity_team_user_id(self):
-        if not self.activity_team_user_id or (
-            self.activity_team_user_id
-            and self.activity_team_user_id in self.activity_team_id.member_ids
-        ):
-            return
-        self.activity_team_id = self.env["mail.activity"]._get_default_team_id(
-            self.activity_team_user_id.id, self.sudo().res_model_id.id
-        )
+    @api.onchange("activity_type_id")
+    def _onchange_activity_type_id(self):
+        if self.activity_type_id.default_team_id:
+            self.activity_team_id = self.activity_type_id.default_team_id
+            members = self.activity_type_id.default_team_id.member_ids
+            if self.activity_user_id not in members and members:
+                self.activity_user_id = members[:1]
 
     def _action_schedule_activities(self):
         return self._get_applied_on_records().activity_schedule(


### PR DESCRIPTION
Regression of https://github.com/OCA/mail/pull/149

Fixes
```
  File "/mnt/data/odoo-addons-dir/mail_activity_team/wizard/mail_activity_schedule.py", line 53, in _onchange_activity_team_user_id
    and self.activity_team_user_id in self.activity_team_id.member_ids
  File "/opt/odoo/odoo/fields.py", line 3113, in __get__
    return super().__get__(records, owner)
  File "/opt/odoo/odoo/fields.py", line 1244, in __get__
    self.recompute(record)
  File "/opt/odoo/odoo/fields.py", line 1471, in recompute
    apply_except_missing(self.compute_value, recs)
  File "/opt/odoo/odoo/fields.py", line 1444, in apply_except_missing
    func(records)
  File "/opt/odoo/odoo/fields.py", line 1493, in compute_value
    records._compute_field_value(self)
  File "/opt/odoo/odoo/models.py", line 5302, in _compute_field_value
    fields.determine(field.compute, self)
  File "/opt/odoo/odoo/fields.py", line 110, in determine
    return needle(*args)
  File "/mnt/data/odoo-addons-dir/mail_activity_team/wizard/mail_activity_schedule.py", line 30, in _compute_activity_team_id
    ]._get_default_team_id(
TypeError: MailActivity._get_default_team_id() takes 1 positional argument but 3 were given
```