### PR TITLE
[18.0][FIX] mail_notification_custom_subject: read templates with sudo

### DIFF
--- a/mail_notification_custom_subject/README.rst
+++ b/mail_notification_custom_subject/README.rst
@@ -101,6 +101,10 @@ Contributors
 
   - Eduardo de Miguel
 
+- Codeforward <https://www.codeforward.nl>
+
+  - Sander Lienaerts
+
 Maintainers
 -----------
 

--- a/mail_notification_custom_subject/__manifest__.py
+++ b/mail_notification_custom_subject/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Mail Notification Custom Subject",
     "summary": "Apply a custom subject to mail notifications",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "category": "Social Network",
     "website": "https://github.com/OCA/mail",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/mail_notification_custom_subject/models/mail_thread.py
+++ b/mail_notification_custom_subject/models/mail_thread.py
@@ -46,11 +46,12 @@ class MailThread(models.AbstractModel):
             if subject:
                 # If it already had a defined subject, we must respect it
                 domain += [("position", "!=", "replace")]
+            # Read templates with sudo: they are admin-managed configuration
+            # records, akin to mail.template. Portal and public users may
+            # trigger message_post (e.g. via portal controllers) and must be
+            # able to iterate the templates without hitting ACL errors.
             custom_subjects = (
-                self.env["mail.message.custom.subject"]
-                .sudo()
-                .search(domain)
-                .sudo(False)
+                self.env["mail.message.custom.subject"].sudo().search(domain)
             )
             if not subject:
                 record_name = (

--- a/mail_notification_custom_subject/readme/CONTRIBUTORS.md
+++ b/mail_notification_custom_subject/readme/CONTRIBUTORS.md
@@ -10,3 +10,6 @@
 
 - Moduon \<<https://www.moduon.team>\>  
   - Eduardo de Miguel
+
+- Codeforward \<<https://www.codeforward.nl>\>  
+  - Sander Lienaerts

--- a/mail_notification_custom_subject/tests/test_mail_notification_custom_subject.py
+++ b/mail_notification_custom_subject/tests/test_mail_notification_custom_subject.py
@@ -20,6 +20,7 @@ class TestMailNotificationCustomSubject(BaseCommon):
         )
         cls.admin = new_test_user(cls.env, "boss", "base.group_system")
         new_test_user(cls.env, "worker_custom_subject")
+        new_test_user(cls.env, "portal_custom_subject", "base.group_portal")
         cls.subject_model = cls.env["mail.message.custom.subject"].with_user(cls.admin)
 
     @users("worker_custom_subject")
@@ -210,3 +211,32 @@ class TestMailNotificationCustomSubject(BaseCommon):
         # Get message and check subject
         # No exception should be raised but subject should remain as original.
         self.assertEqual(mail_message_1.subject, "Test partner 1")
+
+    @users("portal_custom_subject")
+    def test_email_subject_template_portal_user(self):
+        """Portal users triggering message_post via sudo (e.g. from a portal
+        controller) must render custom subject templates without hitting ACL
+        errors on mail.message.custom.subject — templates are admin-managed
+        configuration records and should be read with sudo."""
+        self.subject_model.create(
+            {
+                "name": "Test portal template",
+                "model_id": self.env.ref("base.model_res_partner").id,
+                "subtype_ids": [(6, 0, [self.env.ref("mail.mt_comment").id])],
+                "subject_template": "{{object.name or 'n/a'}} - portal",
+            }
+        )
+        portal_user = self.env.user
+        self.assertTrue(portal_user.has_group("base.group_portal"))
+        self.assertFalse(portal_user.has_group("base.group_user"))
+        # Mimic the portal controller pattern: the caller is the portal user,
+        # the record is sudo'd for message_post, and author_id is set to the
+        # portal user's partner.
+        partner = self.env["res.partner"].browse(self.partner_1.id)
+        mail_message = partner.sudo().message_post(
+            body="Test from portal",
+            subtype_xmlid="mail.mt_comment",
+            author_id=portal_user.partner_id.id,
+        )
+        self.assertEqual(mail_message.author_id, portal_user.partner_id)
+        self.assertEqual(mail_message.subject, "Test partner 1 - portal")


### PR DESCRIPTION
### Problem

`mail.thread.message_post` override in this module does:

```python
custom_subjects = (
    self.env["mail.message.custom.subject"]
    .sudo()
    .search(domain)
    .sudo(False)
)
for template in custom_subjects:
    try:
        ... template.subject_template ...
        ... template.position ...
    except Exception:
        _logger.warning(...)
```

The `.sudo(False)` explicitly drops back to the caller's environment. When a non-internal user (portal or public) triggers `message_post` — typically via a portal controller that does `record.sudo().message_post(...)` — the subsequent field reads check ACL against the caller. The module's ACL only grants `base.group_user` read and `base.group_system` full access on `mail.message.custom.subject`, so portal/public users get an `AccessError`.

The per-template `try/except Exception` catches the error, so the message gets posted without the custom subject being applied (silent degradation). However the `AccessError` can also leak from places outside the try block — e.g. prefetch on related fields triggered by iteration — and surfaces to the caller as a hard failure.

### Fix (this PR)

Read the templates with sudo and drop the `.sudo(False)` switch-back. These templates are admin-managed configuration records, analogous to `mail.template` / `ir.sequence`, and should always be readable by whoever invokes `message_post`. Template rendering itself still honors the caller's permissions on the business record via `res_ids`, so evaluating `{{object.xxx}}` expressions remains bounded by the user's access on the business model.

### Alternative approach considered

Instead of the code change, the ACL could be extended with explicit portal and public read access:

```csv
access_mail_message_custom_subject_portal,...,base.group_portal,1,0,0,0
access_mail_message_custom_subject_public,...,base.group_public,1,0,0,0
```

This preserves the `.sudo(False)` pattern and makes permissions explicit. Trade-offs vs. the current PR:

- **For ACL approach:** less invasive, keeps the original security-aware iteration pattern, makes permission grants auditable in the CSV.
- **Against ACL approach:** exposes configuration records to portal/public users (harmless subject templates, but still visible); requires remembering to cover both `base.group_portal` and `base.group_public`; the pattern remains inconsistent — the `.sudo()` before `.search(domain)` already acknowledges that all matching templates must be found regardless of caller permissions, so it is odd to then flip back to `.sudo(False)` only for the reads that follow.
- **For the code change (current PR):** single change covers all non-internal users, consistent with how `mail.template` is handled in Odoo core (admin-managed rendering config, always read with sudo during message flows).

Happy to switch to the ACL approach if maintainers prefer that.

### Test

Added `test_email_subject_template_portal_user` that:

1. Creates a `base.group_portal` user.
2. Creates a template as admin.
3. Posts a message as the portal user via `partner.sudo().message_post(...)` — the exact pattern used by portal controllers.
4. Asserts the subject is rendered from the template.

Without this fix the test fails (subject falls back to `Re: Test partner 1`); with the fix it passes.
