### PR TITLE
[18.0][IMP] mail_attach_existing_attachment: Add more information in the attachment display name

### DIFF
--- a/mail_attach_existing_attachment/__init__.py
+++ b/mail_attach_existing_attachment/__init__.py
@@ -1,1 +1,2 @@
+from . import models
 from . import wizard

--- a/mail_attach_existing_attachment/models/__init__.py
+++ b/mail_attach_existing_attachment/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_attachment

--- a/mail_attach_existing_attachment/models/ir_attachment.py
+++ b/mail_attach_existing_attachment/models/ir_attachment.py
@@ -1,0 +1,18 @@
+from odoo import api, models
+from odoo.tools import format_datetime
+
+
+class IrAttachment(models.Model):
+    _inherit = "ir.attachment"
+
+    @api.depends_context("display_full_attachment_name")
+    def _compute_display_name(self):
+        if not self.env.context.get("display_full_attachment_name"):
+            return super()._compute_display_name()
+        for attachment in self:
+            names = [
+                attachment.name,
+                attachment.create_uid.name,
+                format_datetime(self.env, attachment.create_date),
+            ]
+            attachment.display_name = " - ".join(names)

--- a/mail_attach_existing_attachment/wizard/mail_compose_message_view.xml
+++ b/mail_attach_existing_attachment/wizard/mail_compose_message_view.xml
@@ -12,6 +12,7 @@
                     widget="many2many_checkboxes"
                     domain="[('id', 'in', display_object_attachment_ids)]"
                     invisible="not can_attach_attachment"
+                    context="{'display_full_attachment_name': True}"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
When a message contains multiple attachments, including duplicates or files with the same name, it becomes difficult to distinguish them.

This commit improves the display name of attachments by adding the creator (user) and creation date, making it easier to differentiate records.

Before
<img width="685" height="505" alt="image" src="https://github.com/user-attachments/assets/256aa083-7f80-4509-9e40-da0d1b7d8c6b" />

After
<img width="685" height="505" alt="image" src="https://github.com/user-attachments/assets/6d9edf93-1a98-4e4c-a34a-beead94aa774" />


FWP of https://github.com/OCA/social/pull/1736

TT62629
@Tecnativa @pedrobaeza could you please review this?