### PR TITLE
[18.0][FIX] mail_drop_target: drop existing display defined message

### DIFF
--- a/mail_drop_target/controllers/discuss.py
+++ b/mail_drop_target/controllers/discuss.py
@@ -42,9 +42,8 @@ class AttachmentController(attachment.AttachmentController):
                 return False
             responseData = {"email_upload": 1}
         except AccessError:
-            responseData = {
-                "error": _("You are not allowed to upload an attachment here.")
-            }
+            message = _("You are not allowed to upload an attachment here.")
+            responseData = {"error": {"message": message}}
         except UserError as err:
-            responseData = {"error": str(err)}
+            responseData = {"error": {"message": str(err)}}
         return request.make_json_response(responseData)

--- a/mail_drop_target/models/mail_thread.py
+++ b/mail_drop_target/models/mail_thread.py
@@ -8,6 +8,7 @@ import chardet
 import lxml.html
 
 from odoo import _, api, exceptions, models
+from odoo.tools import str2bool
 
 try:
     from extract_msg import Message
@@ -28,7 +29,7 @@ class MailThread(models.AbstractModel):
         strip_attachments=False,
         thread_id=None,
     ):
-        disable_notify_mail_drop_target = (
+        disable_notify_mail_drop_target = str2bool(
             self.env["ir.config_parameter"]
             .sudo()
             .get_param("mail_drop_target.disable_notify", default=False)

--- a/mail_drop_target/models/mail_thread.py
+++ b/mail_drop_target/models/mail_thread.py
@@ -1,6 +1,8 @@
 # Copyright 2018 Therp BV <https://therp.nl>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from base64 import b64decode
+from email import message_from_bytes, policy
+from xmlrpc import client as xmlrpclib
 
 import chardet
 import lxml.html
@@ -65,8 +67,58 @@ class MailThread(models.AbstractModel):
         strip_attachments=False,
         thread_id=None,
     ):
-        message = _("This message is already imported.")
-        raise exceptions.UserError(message)
+        message_id = self._mail_drop_get_message_id(message)
+        existing = (
+            self.env["mail.message"]
+            .sudo()
+            .search([("message_id", "=", message_id)], limit=1)
+            if message_id
+            else self.env["mail.message"]
+        )
+        error = _("This message is already imported. ")
+        if not existing:
+            raise exceptions.UserError(error)
+        locations = self._mail_drop_describe_existing(existing)
+        if locations:
+            error += _(
+                "The already imported copy is attached to: %(locations)s",
+                locations=locations,
+            )
+        raise exceptions.UserError(error)
+
+    @api.model
+    def _mail_drop_get_message_id(self, message):
+        if isinstance(message, xmlrpclib.Binary):
+            message = bytes(message.data)
+        if isinstance(message, str):
+            message = message.encode("utf-8")
+        mail = message_from_bytes(message, policy=policy.SMTP)
+        message_id = mail.get("Message-Id")
+        return message_id.strip() if message_id else False
+
+    @api.model
+    def _mail_drop_describe_existing(self, messages):
+        if (
+            not messages
+            or not messages.model
+            or not messages.res_id
+            or messages.model not in self.env
+        ):
+            return False
+        try:
+            record = self.env[messages.model].browse(messages.res_id).exists()
+            name = (
+                record.display_name if record else _("a record that no longer exists.")
+            )
+        except exceptions.AccessError:
+            name = _("a record you are not allowed to access.")
+        model_label = self.env["ir.model"]._get(messages.model).name or messages.model
+        return _(
+            "%(model)s --> %(name)s (ID = %(res_id)s).",
+            model=model_label,
+            name=name,
+            res_id=messages.res_id,
+        )
 
     @api.model
     def message_process_msg(

--- a/mail_drop_target/tests/test_mail_drop_target.py
+++ b/mail_drop_target/tests/test_mail_drop_target.py
@@ -100,3 +100,26 @@ class TestMailDropTarget(TransactionCase):
             self.partner.message_process_msg(
                 self.partner._name, message, thread_id=self.partner.id
             )
+
+    def test_duplicate_error_message_details(self):
+        message = tools.file_open("addons/mail_drop_target/tests/sample.eml").read()
+        self.partner.message_process(
+            self.partner._name, message, thread_id=self.partner.id
+        )
+        with self.assertRaises(exceptions.UserError) as catcher:
+            self.partner.message_drop(
+                self.partner._name, message, thread_id=self.partner.id
+            )
+        error_message = str(catcher.exception)
+        self.assertIn("already imported", error_message)
+        # The record the existing copy is attached to is described.
+        self.assertIn(self.partner.display_name, error_message)
+        self.assertIn(str(self.partner.id), error_message)
+
+    def test_drop_existing_without_match(self):
+        message = "Message-Id: <unknown-message-id@example.com>\n\nBody"
+        with self.assertRaises(exceptions.UserError) as catcher:
+            self.env["res.partner"].message_drop_existing("res.partner", message)
+        error_message = str(catcher.exception)
+        self.assertIn("already imported", error_message)
+        self.assertNotIn("attached to", error_message)


### PR DESCRIPTION
When dropping an email file that Odoo fails to import (ignores any email whose Message-Id already exists), the chatter only showed the generic _"An error occured while uploading."_ notification. This fixes that behavior so the actual message is rendered in the UI. It also improves the message itself: reports which record the already-imported copy is attached to.

**Before**
<img width="413" height="89" alt="image" src="https://github.com/user-attachments/assets/b97ba699-98d0-4b87-9c2a-d688d7b1dce3" />

**After**
<img width="419" height="146" alt="image" src="https://github.com/user-attachments/assets/4fc738e5-3e33-478a-945f-e0783db4a366" />

A separate commit reads the disable_notify param with str2bool, so a stored "False" value is no longer treated as truthy.
