### PR TITLE
[18.0][FIX] mail_tracking: Do not hide exception if not managed

### DIFF
--- a/mail_tracking/models/ir_mail_server.py
+++ b/mail_tracking/models/ir_mail_server.py
@@ -159,6 +159,8 @@ class IrMailServer(models.Model):
         except Exception as e:
             if tracking_email:
                 tracking_email.smtp_error(self, smtp_server_used, e)
+            else:
+                raise
         if message_id and tracking_email:
             vals = tracking_email._tracking_sent_prepare(
                 self, smtp_server_used, message, message_id


### PR DESCRIPTION
Raise original exception if not managed by this module.

For my use case, a badly migrated module was missing some arguments and no exception was raised because of this module:
<img width="1409" height="641" alt="image" src="https://github.com/user-attachments/assets/39974a0b-f704-4126-bc3f-7858eb483ead" />
