### PR TITLE
[19.0][FIX] mail_tracking: make message route test compatible with overrides

### DIFF
--- a/mail_tracking/tests/test_mail_tracking.py
+++ b/mail_tracking/tests/test_mail_tracking.py
@@ -379,6 +379,9 @@ class TestMailTracking(TransactionCase, MockSmtplibCase):
             "cc": "copy@example.com",
             "to": "recipient@example.com",
             "message_id": "test-message-id",
+            # Optional mail headers used by mail.thread overrides (e.g. mass_mailing).
+            "references": "",
+            "in_reply_to": "",
         }
         with patch.object(
             CoreMailThread,


### PR DESCRIPTION
Add optional mail headers expected by inherited `mail.thread` implementations, avoiding failures when modules such as `mass_mailing` are installed.

@Tecnativa TT63167

@pedrobaeza @victoralmau please review