### PR TITLE
[19.0][FIX] mail_tracking: complete message route test payload

### DIFF
--- a/mail_tracking/tests/test_mail_tracking.py
+++ b/mail_tracking/tests/test_mail_tracking.py
@@ -399,7 +399,12 @@ class TestMailTracking(TransactionCase, MockSmtplibCase):
             mock_super.call_args.args[2]["email_to"], "recipient@example.com"
         )
 
-        message_dict = {"message_id": "test-message-id"}
+        message_dict = {
+            "message_id": "test-message-id",
+            # Optional mail headers used by mail.thread overrides (e.g. mass_mailing).
+            "references": "",
+            "in_reply_to": "",
+        }
         with patch.object(
             CoreMailThread,
             "_message_route_process",


### PR DESCRIPTION
The previous commit inadvertently missed the changes to the second mocked message_dict used by the same test. This PR completes the fix by applying the same update there as well.

Add the optional mail headers to the second payload as well to keep the test compatible with inherited mail.thread implementations such as mass_mailing.

@Tecnativa TT63167

@pedrobaeza @victoralmau please review