### PR TITLE
[19.0][FIX] mail_tracking_mailgun: Remove DeprecationWarning warning

### DIFF
--- a/mail_tracking_mailgun/controllers/main.py
+++ b/mail_tracking_mailgun/controllers/main.py
@@ -4,7 +4,7 @@
 import hashlib
 import hmac
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from werkzeug.exceptions import NotAcceptable
 
@@ -25,7 +25,9 @@ class MailTrackingController(main.MailTrackingController):
         See https://documentation.mailgun.com/en/latest/user_manual.html#securing-webhooks
         """  # noqa: E501
         # Request cannot be old
-        processing_time = datetime.utcnow() - datetime.utcfromtimestamp(int(timestamp))
+        processing_time = datetime.now(timezone.utc) - datetime.fromtimestamp(
+            int(timestamp), timezone.utc
+        )
         if not timedelta() < processing_time < timedelta(minutes=10):
             raise ValidationError(request.env._("Request is too old"))
         # Avoid replay attacks

--- a/mail_tracking_mailgun/models/mail_tracking_email.py
+++ b/mail_tracking_mailgun/models/mail_tracking_email.py
@@ -5,7 +5,7 @@
 
 import logging
 from collections import namedtuple
-from datetime import datetime
+from datetime import datetime, timezone
 from urllib.parse import urljoin
 
 import requests
@@ -103,7 +103,7 @@ class MailTrackingEmail(models.Model):
         except Exception:
             ts = False
         if ts:
-            dt = datetime.utcfromtimestamp(ts)
+            dt = datetime.fromtimestamp(ts, timezone.utc)
             metadata.update(
                 {
                     "timestamp": ts,


### PR DESCRIPTION
Remove DeprecationWarning warning

`WARNING prod py.warnings: /opt/odoo/auto/addons/mail_tracking_mailgun/controllers/main.py:28: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).`

`WARNING prod py.warnings: /opt/odoo/auto/addons/mail_tracking_mailgun/models/mail_tracking_email.py:106: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).`

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa