### PR TITLE
[19.0][FIX] mail_activity_team: broken layout

### DIFF
--- a/mail_activity_team/__manifest__.py
+++ b/mail_activity_team/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Mail Activity Team",
     "summary": "Add Teams to Activities",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "development_status": "Beta",
     "category": "Social Network",
     "website": "https://github.com/OCA/mail",

--- a/mail_activity_team/models/mail_activity.py
+++ b/mail_activity_team/models/mail_activity.py
@@ -4,6 +4,8 @@
 from odoo import SUPERUSER_ID, api, fields, models
 from odoo.exceptions import ValidationError
 
+from odoo.addons.mail.tools.discuss import Store
+
 
 class MailActivity(models.Model):
     _inherit = "mail.activity"
@@ -130,3 +132,6 @@ class MailActivity(models.Model):
             if self.user_id not in members and members:
                 self.user_id = members[:1]
         return res
+
+    def _to_store_defaults(self, target):
+        return super()._to_store_defaults(target) + [Store.One("team_id", ["name"])]

--- a/mail_activity_team/readme/CONTRIBUTORS.md
+++ b/mail_activity_team/readme/CONTRIBUTORS.md
@@ -15,3 +15,5 @@
 - [CorporateHub](https://corporatehub.eu/)
   - Alexey Pelykh <alexey.pelykh@corphub.eu>
 - Stefan Rijnhart (<stefan@opener.amsterdam>)
+- [Digiteasy](https://www.digiteasy.at/)
+  - Alvaro Estebanez

--- a/mail_activity_team/static/src/core/common/activity_model_patch.esm.js
+++ b/mail_activity_team/static/src/core/common/activity_model_patch.esm.js
@@ -1,0 +1,11 @@
+import {Activity} from "@mail/core/common/activity_model";
+import {fields} from "@mail/core/common/record";
+
+import {patch} from "@web/core/utils/patch";
+
+patch(Activity.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.team_id = fields.One("mail.activity.team");
+    },
+});

--- a/mail_activity_team/static/src/core/common/mail_activity_team_model.esm.js
+++ b/mail_activity_team/static/src/core/common/mail_activity_team_model.esm.js
@@ -1,0 +1,9 @@
+import {Record} from "@mail/core/common/record";
+
+export class MailActivityTeam extends Record {
+    static _name = "mail.activity.team";
+    /** @type {String} */
+    name;
+}
+
+MailActivityTeam.register();

--- a/mail_activity_team/static/src/core/web/activity.xml
+++ b/mail_activity_team/static/src/core/web/activity.xml
@@ -6,20 +6,6 @@
         t-inherit="mail.Activity"
         t-inherit-mode="extension"
     >
-        <!-- Prevent error rendering the avatar in case of missing user -->
-        <xpath
-            expr="//div/div[hasclass('o-mail-Activity-sidebar')]/a/img"
-            position="attributes"
-        >
-            <attribute name="t-if">props.activity.user_id</attribute>
-        </xpath>
-        <!-- Prevent error rendering the assigned user in case of missing user -->
-        <xpath
-            expr="//div/div/div[hasclass('o-mail-Activity-info')]/span[hasclass('o-mail-Activity-user')]"
-            position="attributes"
-        >
-            <attribute name="t-if">props.activity.user_id</attribute>
-        </xpath>
         <!-- Show team in the condensed view -->
         <xpath
             expr="//div/div/div[hasclass('o-mail-Activity-info')]/span[hasclass('o-mail-Activity-user')]"
@@ -28,25 +14,15 @@
             <span
                 class="o-mail-Activity-user px-1"
                 t-if="props.activity.team_id"
-            >(Team <t t-esc="props.activity.team_id[1]" />)
+            >(Team <t t-esc="props.activity.team_id.name" />)
             </span>
         </xpath>
-        <!-- Prevent error rendering the assigned user in case of missing user in the expanded view -->
-        <xpath
-            expr="//t[@t-esc='props.activity.persona.name']/parent::td/parent::tr"
-            position="attributes"
-        >
-            <attribute name="t-if">props.activity.user_id</attribute>
-        </xpath>
         <!-- Show team in the expanded view -->
-        <xpath
-            expr="//t[@t-esc='props.activity.persona.name']/parent::td/parent::tr"
-            position="after"
-        >
+        <xpath expr="//tr[@t-if='props.activity.user_id']" position="after">
             <tr t-if="props.activity.team_id">
                 <td class="text-end fw-bolder">Team</td>
                 <td>
-                    <t t-esc="props.activity.team_id[1]" />
+                    <t t-esc="props.activity.team_id.name" />
                 </td>
             </tr>
         </xpath>


### PR DESCRIPTION
 - adaptions to fix the layout according to https://github.com/odoo/odoo/commit/020a57bc509a49189fb3c3abe47dbe0edbfbdd5b

Records with activities cannot be loaded because the XML for activities has changed. This fixes errors like:
```
Caused by: Error: Element '<xpath expr="//div/div[hasclass('o-mail-Activity-sidebar')]/a/img" position="attributes">
                <attribute name="t-if">props.activity.user_id</attribute>
            </xpath>' cannot be located in element tree
    Error: Element '<xpath expr="//div/div[hasclass('o-mail-Activity-sidebar')]/a/img" position="attributes">
                <attribute name="t-if">props.activity.user_id</attribute>
            </xpath>' cannot be located in element tree
```