### PR TITLE
[19.0][IMP] mail_attach_existing_attachment: foldable attachment sections

### DIFF
--- a/mail_attach_existing_attachment/README.rst
+++ b/mail_attach_existing_attachment/README.rst
@@ -55,6 +55,17 @@ To use this module, you need to:
 
 |image2|
 
+The composer groups attachments under two headers, each folding away
+when its title is clicked:
+
+- **New Attachments** lists the files added to this email as cards, and
+  only appears once there is at least one.
+- **Available Attachments** is the picker for the files already on the
+  record. It starts folded, and its header shows how many files are on
+  offer, or how many are ticked once you fold it back. Unfolded, it lays
+  the checkboxes out in as many columns as the composer is wide enough
+  for.
+
 .. |image1| image:: https://raw.githubusercontent.com/OCA/mail/19.0/mail_attach_existing_attachment/static/description/attachment.png
 .. |image2| image:: https://raw.githubusercontent.com/OCA/mail/19.0/mail_attach_existing_attachment/static/description/ex_mail_compose_message.png
 
@@ -100,6 +111,10 @@ Contributors
 - `Apik <https://www.aapik.cloud>`__:
 
   - Frederic Grall
+
+- `PureKarting <https://www.purekarting.com>`__:
+
+  - Cliff Kujala
 
 Maintainers
 -----------

--- a/mail_attach_existing_attachment/__manifest__.py
+++ b/mail_attach_existing_attachment/__manifest__.py
@@ -7,9 +7,17 @@
     "author": "ACSONE SA/NV, Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/mail",
     "category": "Social Network",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "license": "AGPL-3",
     "depends": ["mail"],
     "data": ["wizard/mail_compose_message_view.xml"],
+    "assets": {
+        "web.assets_backend": [
+            "mail_attach_existing_attachment/static/src/**/*",
+        ],
+        "web.assets_unit_tests": [
+            "mail_attach_existing_attachment/static/tests/**/*",
+        ],
+    },
     "installable": True,
 }

--- a/mail_attach_existing_attachment/readme/CONTRIBUTORS.md
+++ b/mail_attach_existing_attachment/readme/CONTRIBUTORS.md
@@ -7,3 +7,5 @@
   - Andrea Stirpe
 - [Apik](https://www.aapik.cloud):
   - Frederic Grall
+- [PureKarting](https://www.purekarting.com):
+  - Cliff Kujala

--- a/mail_attach_existing_attachment/readme/USAGE.md
+++ b/mail_attach_existing_attachment/readme/USAGE.md
@@ -8,3 +8,14 @@ To use this module, you need to:
   added earlier
 
 ![](../static/description/ex_mail_compose_message.png)
+
+The composer groups attachments under two headers, each folding away when
+its title is clicked:
+
+- **New Attachments** lists the files added to this email as cards, and
+  only appears once there is at least one.
+- **Available Attachments** is the picker for the files already on the
+  record. It starts folded, and its header shows how many files are on
+  offer, or how many are ticked once you fold it back. Unfolded, it lays
+  the checkboxes out in as many columns as the composer is wide enough
+  for.

--- a/mail_attach_existing_attachment/static/description/index.html
+++ b/mail_attach_existing_attachment/static/description/index.html
@@ -404,6 +404,17 @@ message wizard</p>
 added earlier</li>
 </ul>
 <p><img alt="image2" src="https://raw.githubusercontent.com/OCA/mail/19.0/mail_attach_existing_attachment/static/description/ex_mail_compose_message.png" /></p>
+<p>The composer groups attachments under two headers, each folding away
+when its title is clicked:</p>
+<ul class="simple">
+<li><strong>New Attachments</strong> lists the files added to this email as cards, and
+only appears once there is at least one.</li>
+<li><strong>Available Attachments</strong> is the picker for the files already on the
+record. It starts folded, and its header shows how many files are on
+offer, or how many are ticked once you fold it back. Unfolded, it lays
+the checkboxes out in as many columns as the composer is wide enough
+for.</li>
+</ul>
 </div>
 <div class="section" id="known-issues-roadmap">
 <h2><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h2>
@@ -445,6 +456,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li><a class="reference external" href="https://www.aapik.cloud">Apik</a>:<ul>
 <li>Frederic Grall</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://www.purekarting.com">PureKarting</a>:<ul>
+<li>Cliff Kujala</li>
 </ul>
 </li>
 </ul>

--- a/mail_attach_existing_attachment/static/src/attachment_checkbox_grid.esm.js
+++ b/mail_attach_existing_attachment/static/src/attachment_checkbox_grid.esm.js
@@ -1,0 +1,102 @@
+import {
+    Many2ManyCheckboxesField,
+    many2ManyCheckboxesField,
+} from "@web/views/fields/many2many_checkboxes/many2many_checkboxes_field";
+import {onWillUnmount, useState} from "@odoo/owl";
+import {CheckBox} from "@web/core/checkbox/checkbox";
+import {_t} from "@web/core/l10n/translation";
+import {debounce} from "@web/core/utils/timing";
+import {getFieldDomain} from "@web/model/relational_model/utils";
+import {humanSize} from "@web/core/utils/binary";
+import {registry} from "@web/core/registry";
+import {useBus} from "@web/core/utils/hooks";
+import {useSpecialData} from "@web/views/fields/relational_utils";
+
+/**
+ * Picker for the attachments already linked to the record being sent.
+ *
+ * Same selection semantics as core's ``many2many_checkboxes``, but laid out as
+ * a responsive grid behind a foldable header. A record with a long attachment
+ * history would otherwise push the composer's Send button off screen.
+ */
+export class AttachmentCheckboxGrid extends Many2ManyCheckboxesField {
+    static template = "mail_attach_existing_attachment.AttachmentCheckboxGrid";
+    static components = {CheckBox};
+
+    setup() {
+        // Core's setup is deliberately not called. It loads the choices with
+        // ``name_search``, whose default limit of 100 silently drops the oldest
+        // attachments of a busy record, and it only gets the display name back
+        // - too little to tell apart the "image001.png" a mail thread
+        // accumulates. Everything else it does is the change bookkeeping
+        // replicated below.
+        this.state = useState({folded: true});
+        this.specialData = useSpecialData((orm, props) => {
+            const {relation} = props.record.fields[props.name];
+            const domain = getFieldDomain(props.record, props.name, props.domain);
+            return orm.call(relation, "search_read", [], {
+                context: props.context || {},
+                domain,
+                fields: ["name", "file_size"],
+                order: "id desc",
+            });
+        });
+        this.idsToAdd = new Set();
+        this.idsToRemove = new Set();
+        this.debouncedCommitChanges = debounce(this.commitChanges.bind(this), 500);
+        useBus(
+            this.props.record.model.bus,
+            "NEED_LOCAL_CHANGES",
+            this.commitChanges.bind(this)
+        );
+        onWillUnmount(this.commitChanges.bind(this));
+    }
+
+    /**
+     * @returns {Object[]} the attachments linked to the record, newest first.
+     */
+    get items() {
+        return this.specialData.data || [];
+    }
+
+    /**
+     * @param {Object} attachment
+     * @returns {Boolean}
+     */
+    isSelected(attachment) {
+        return this.props.record.data[this.props.name].currentIds.includes(
+            attachment.id
+        );
+    }
+
+    /**
+     * @returns {Number} how many attachments are ticked, for the folded header.
+     */
+    get selectedCount() {
+        return this.props.record.data[this.props.name].currentIds.length;
+    }
+
+    /**
+     * @param {Object} attachment
+     * @returns {String} the file size, human readable, or an empty string when
+     *  the size is unknown.
+     */
+    sizeLabel(attachment) {
+        return attachment.file_size ? humanSize(attachment.file_size) : "";
+    }
+
+    toggleFolded() {
+        // Ticking a box only reaches the record after a debounce, so flush
+        // before folding: the count in the header has to be the real one.
+        this.commitChanges();
+        this.state.folded = !this.state.folded;
+    }
+}
+
+export const attachmentCheckboxGrid = {
+    ...many2ManyCheckboxesField,
+    component: AttachmentCheckboxGrid,
+    displayName: _t("Attachment checkbox grid"),
+};
+
+registry.category("fields").add("attachment_checkbox_grid", attachmentCheckboxGrid);

--- a/mail_attach_existing_attachment/static/src/attachment_checkbox_grid.scss
+++ b/mail_attach_existing_attachment/static/src/attachment_checkbox_grid.scss
@@ -1,0 +1,28 @@
+// Copyright 2026 PureKarting
+// License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+.o_attachment_checkbox_grid_items {
+    // auto-fill against a min column width makes the number of columns follow
+    // the composer's own width, without a media query: the composer is a
+    // dialog, so the viewport says nothing useful about how wide it is.
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+    column-gap: 1rem;
+
+    > .o-checkbox {
+        min-width: 0;
+
+        .form-check-label {
+            display: flex;
+            align-items: baseline;
+            min-width: 0;
+            max-width: 100%;
+        }
+
+        .form-check-label > :first-child {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+    }
+}

--- a/mail_attach_existing_attachment/static/src/attachment_checkbox_grid.xml
+++ b/mail_attach_existing_attachment/static/src/attachment_checkbox_grid.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Copyright 2026 PureKarting
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<templates xml:space="preserve">
+
+    <t t-name="mail_attach_existing_attachment.AttachmentCheckboxGrid">
+        <div t-if="items.length" class="o_attachment_checkbox_grid">
+            <div class="d-flex pt-2 cursor-pointer fw-bolder" t-on-click="toggleFolded">
+                <hr class="flex-grow-1 fs-3" />
+                <div class="d-flex align-items-center px-3">
+                    <i
+                        class="fa fa-fw"
+                        t-att-class="state.folded ? 'fa-caret-right' : 'fa-caret-down'"
+                    />
+                    <span>Available Attachments</span>
+                    <span
+                        class="badge rounded-pill ms-2"
+                        t-att-class="state.folded and selectedCount ? 'text-bg-primary' : 'text-bg-secondary'"
+                        t-out="state.folded and selectedCount ? selectedCount : items.length"
+                    />
+                </div>
+                <hr class="flex-grow-1 fs-3" />
+            </div>
+            <div t-if="!state.folded" class="o_attachment_checkbox_grid_items pb-2">
+                <CheckBox
+                    t-foreach="items"
+                    t-as="attachment"
+                    t-key="attachment.id"
+                    value="isSelected(attachment)"
+                    disabled="props.readonly"
+                    onChange="(checked) => this.onChange(attachment.id, checked)"
+                >
+                    <span t-att-title="attachment.name" t-out="attachment.name" />
+                    <span
+                        t-if="sizeLabel(attachment)"
+                        class="text-muted small ms-1"
+                        t-out="sizeLabel(attachment)"
+                    />
+                </CheckBox>
+            </div>
+        </div>
+    </t>
+
+</templates>

--- a/mail_attach_existing_attachment/static/src/mail_composer_attachment_thumbnails.esm.js
+++ b/mail_attach_existing_attachment/static/src/mail_composer_attachment_thumbnails.esm.js
@@ -1,0 +1,63 @@
+import {
+    MailComposerAttachmentList,
+    mailComposerAttachmentList,
+} from "@mail/core/web/mail_composer_attachment_list";
+import {onWillRender, useState, useSubEnv} from "@odoo/owl";
+import {AttachmentList} from "@mail/core/common/attachment_list";
+import {_t} from "@web/core/l10n/translation";
+import {registry} from "@web/core/registry";
+
+/**
+ * The files the user just added, as thumbnail cards behind a foldable header.
+ *
+ * Core renders them as a plain list of links. Cards make an image or a PDF
+ * recognisable at a glance, which matters once the composer also offers the
+ * attachments already on the record: the two sections have to be told apart.
+ * Rendering is delegated to the very component the chatter uses, so the cards
+ * look and behave exactly like the ones next to a posted message.
+ */
+export class MailComposerAttachmentThumbnails extends MailComposerAttachmentList {
+    static template =
+        "mail_attach_existing_attachment.MailComposerAttachmentThumbnails";
+    static components = {AttachmentList};
+
+    setup() {
+        super.setup();
+        // ``AttachmentList`` reads this to offer Remove rather than Download,
+        // and to unlink without a confirmation dialog.
+        useSubEnv({inComposer: true});
+        this.state = useState({folded: false});
+        /** @type {import("models").Attachment[]} */
+        this.attachments = [];
+        onWillRender(() => {
+            this.attachments = this.files.map((file) =>
+                this.mailStore["ir.attachment"].insert({
+                    id: file.id,
+                    mimetype: file.mimetype,
+                    name: file.name,
+                })
+            );
+        });
+    }
+
+    /**
+     * @param {import("models").Attachment} attachment
+     */
+    unlinkAttachment(attachment) {
+        return this.onFileRemove(attachment.id);
+    }
+
+    toggleFolded() {
+        this.state.folded = !this.state.folded;
+    }
+}
+
+export const mailComposerAttachmentThumbnails = {
+    ...mailComposerAttachmentList,
+    component: MailComposerAttachmentThumbnails,
+    displayName: _t("Composer attachment thumbnails"),
+};
+
+registry
+    .category("fields")
+    .add("mail_composer_attachment_thumbnails", mailComposerAttachmentThumbnails);

--- a/mail_attach_existing_attachment/static/src/mail_composer_attachment_thumbnails.scss
+++ b/mail_attach_existing_attachment/static/src/mail_composer_attachment_thumbnails.scss
@@ -1,0 +1,8 @@
+// Copyright 2026 PureKarting
+// License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+.o_field_mail_composer_attachment_thumbnails {
+    // Same override core applies to the link list it replaces: the field has
+    // to span the composer rather than sit in an inline field cell.
+    --fieldWidget-display: block;
+}

--- a/mail_attach_existing_attachment/static/src/mail_composer_attachment_thumbnails.xml
+++ b/mail_attach_existing_attachment/static/src/mail_composer_attachment_thumbnails.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Copyright 2026 PureKarting
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<templates xml:space="preserve">
+
+    <t t-name="mail_attach_existing_attachment.MailComposerAttachmentThumbnails">
+        <div t-if="files.length" class="o_mail_composer_attachment_thumbnails">
+            <div class="d-flex pt-2 cursor-pointer fw-bolder" t-on-click="toggleFolded">
+                <hr class="flex-grow-1 fs-3" />
+                <div class="d-flex align-items-center px-3">
+                    <i
+                        class="fa fa-fw"
+                        t-att-class="state.folded ? 'fa-caret-right' : 'fa-caret-down'"
+                    />
+                    <span>New Attachments</span>
+                    <span
+                        class="badge rounded-pill ms-2 text-bg-secondary"
+                        t-out="files.length"
+                    />
+                </div>
+                <hr class="flex-grow-1 fs-3" />
+            </div>
+            <AttachmentList
+                t-if="!state.folded"
+                attachments="attachments"
+                unlinkAttachment.bind="unlinkAttachment"
+            />
+        </div>
+    </t>
+
+</templates>

--- a/mail_attach_existing_attachment/static/tests/attachment_sections.test.js
+++ b/mail_attach_existing_attachment/static/tests/attachment_sections.test.js
@@ -1,0 +1,128 @@
+import {
+    click,
+    contains,
+    defineMailModels,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
+import {describe, test} from "@odoo/hoot";
+import {mountView} from "@web/../tests/web_test_helpers";
+import {runAllTimers} from "@odoo/hoot-mock";
+
+describe.current.tags("desktop");
+defineMailModels();
+
+const GRID = ".o_attachment_checkbox_grid";
+const NEW = ".o_mail_composer_attachment_thumbnails";
+
+/*
+ * ``display_object_attachment_ids`` is computed, which the mock server does not
+ * do, so the arch below filters on ``res_model`` directly. What the widgets do
+ * with the choices they are handed is what these tests are about; the compute
+ * itself is covered by the Python tests.
+ */
+const ARCH = `
+    <form>
+        <field name="attachment_ids" widget="mail_composer_attachment_thumbnails"/>
+        <field name="object_attachment_ids" widget="attachment_checkbox_grid"
+               domain="[('res_model', '=', 'res.partner')]"/>
+    </form>`;
+
+/**
+ * @param {Object} pyEnv
+ * @param {String[]} names
+ * @returns {Number[]} the ids of attachments linked to a fresh partner
+ */
+function attachRecordFiles(pyEnv, names) {
+    const partnerId = pyEnv["res.partner"].create({name: "Jean Neige"});
+    return names.map((name) =>
+        pyEnv["ir.attachment"].create({
+            file_size: 2048,
+            mimetype: "application/pdf",
+            name,
+            res_id: partnerId,
+            res_model: "res.partner",
+        })
+    );
+}
+
+test("available attachments start folded and unfold into a grid", async () => {
+    const pyEnv = await startServer();
+    attachRecordFiles(pyEnv, ["quote.pdf", "specs.pdf", "photo.pdf"]);
+    const composerId = pyEnv["mail.compose.message"].create({});
+    await mountView({
+        arch: ARCH,
+        resId: composerId,
+        resModel: "mail.compose.message",
+        type: "form",
+    });
+    await contains(`${GRID} .fa-caret-right`);
+    await contains(`${GRID} .badge`, {text: "3"});
+    await contains(`${GRID} .o-checkbox`, {count: 0});
+    await click(`${GRID} > .cursor-pointer`);
+    await contains(`${GRID} .fa-caret-down`);
+    await contains(`${GRID}_items .o-checkbox`, {count: 3});
+    await contains(`${GRID}_items`, {text: "quote.pdf"});
+});
+
+test("folded header counts the ticked attachments", async () => {
+    const pyEnv = await startServer();
+    attachRecordFiles(pyEnv, ["quote.pdf", "specs.pdf", "photo.pdf"]);
+    const composerId = pyEnv["mail.compose.message"].create({});
+    await mountView({
+        arch: ARCH,
+        resId: composerId,
+        resModel: "mail.compose.message",
+        type: "form",
+    });
+    await click(`${GRID} > .cursor-pointer`);
+    await click(`${GRID}_items .o-checkbox input`);
+    await runAllTimers();
+    await click(`${GRID} > .cursor-pointer`);
+    await contains(`${GRID} .badge`, {text: "1"});
+});
+
+test("no available attachments section when the record has none", async () => {
+    const pyEnv = await startServer();
+    const composerId = pyEnv["mail.compose.message"].create({});
+    await mountView({
+        arch: ARCH,
+        resId: composerId,
+        resModel: "mail.compose.message",
+        type: "form",
+    });
+    await contains(".o_form_view");
+    await contains(GRID, {count: 0});
+});
+
+test("new attachments show as cards, and only once there is one", async () => {
+    const pyEnv = await startServer();
+    const emptyId = pyEnv["mail.compose.message"].create({});
+    await mountView({
+        arch: ARCH,
+        resId: emptyId,
+        resModel: "mail.compose.message",
+        type: "form",
+    });
+    await contains(".o_form_view");
+    await contains(NEW, {count: 0});
+
+    const attachmentId = pyEnv["ir.attachment"].create({
+        mimetype: "application/pdf",
+        name: "draft.pdf",
+        res_id: 0,
+        res_model: "mail.compose.message",
+    });
+    const composerId = pyEnv["mail.compose.message"].create({
+        attachment_ids: [attachmentId],
+    });
+    await mountView({
+        arch: ARCH,
+        resId: composerId,
+        resModel: "mail.compose.message",
+        type: "form",
+    });
+    await contains(`${NEW} .o-mail-AttachmentCard`, {text: "draft.pdf"});
+    await contains(`${NEW} .badge`, {text: "1"});
+    await click(`${NEW} > .cursor-pointer`);
+    await contains(`${NEW} .o-mail-AttachmentCard`, {count: 0});
+});

--- a/mail_attach_existing_attachment/wizard/mail_compose_message_view.xml
+++ b/mail_attach_existing_attachment/wizard/mail_compose_message_view.xml
@@ -4,12 +4,22 @@
         <field name="model">mail.compose.message</field>
         <field name="inherit_id" ref="mail.email_compose_message_wizard_form" />
         <field name="arch" type="xml">
+            <!--
+                Only the first match is patched, which is the comment-mode
+                composer. The mass-mail page keeps the stock widget: attaching
+                the record's own files makes no sense when sending to many
+                records, which is also why ``can_attach_attachment`` stays
+                False there.
+            -->
+            <xpath expr="//field[@name='attachment_ids']" position="attributes">
+                <attribute name="widget">mail_composer_attachment_thumbnails</attribute>
+            </xpath>
             <xpath expr="//field[@name='attachment_ids']" position="after">
                 <field name="can_attach_attachment" invisible="1" />
                 <field name="display_object_attachment_ids" invisible="1" />
                 <field
                     name="object_attachment_ids"
-                    widget="many2many_checkboxes"
+                    widget="attachment_checkbox_grid"
                     domain="[('id', 'in', display_object_attachment_ids)]"
                     invisible="not can_attach_attachment"
                 />


### PR DESCRIPTION
## What

The composer lists every attachment already on the record as one long column of checkboxes. On a record with any mail history that column pushes the Send button off screen, and the filenames a mail thread accumulates (`image001.png`, `image002.png`, ...) are impossible to tell apart.

This groups the composer's attachments under two foldable headers, using the same `hr`/caret header core already uses for Planned Activities:

- **Available Attachments** is the existing picker. It starts folded, its header counts what is on offer (or what is ticked, once folded back), and unfolded it lays the checkboxes out in as many columns as the composer is wide enough for. The grid is `repeat(auto-fill, minmax(15rem, 1fr))`, so the column count follows the dialog's own width rather than the viewport's.
- **New Attachments** shows the files added to this mail as the same cards the chatter uses (`AttachmentList`), instead of the plain list of links Odoo 19 renders. It only appears once there is at least one file.

The picker also loads its choices with `search_read` rather than `name_search`, whose default limit of 100 silently dropped the oldest attachments of a busy record, and shows each file's size.

Only the comment-mode composer is touched. Mass mail keeps the stock widget, which is consistent with `can_attach_attachment` already being False there.

## Test plan

- [x] Existing Python tests pass.
- [ ] Open the full composer on a record with several attachments: Available Attachments is folded and badged with the count.
- [ ] Unfold it and resize the dialog: the checkboxes reflow between 1, 2 and 3 columns.
- [ ] Tick a couple, fold it back: the badge shows how many are ticked, and sending still attaches them.
- [ ] Attach a file: New Attachments appears with a card, and its remove button still deletes the upload.