### PR TITLE
[19.0][IMP] mail_attach_existing_attachment_account: foldable attachment picker

### DIFF
--- a/mail_attach_existing_attachment_account/README.rst
+++ b/mail_attach_existing_attachment_account/README.rst
@@ -36,6 +36,10 @@ This Module adds the mail_attach_existing_attachment feature to the
 account module, since there is a change in odoo 12.0, which adds a new
 mail wizard form to the account module
 
+The invoice's attachments are offered through the same foldable,
+multi-column picker the mail composer uses, so a long-lived invoice does
+not bury the wizard's own buttons under a column of checkboxes.
+
 **Table of contents**
 
 .. contents::
@@ -77,6 +81,10 @@ Contributors
   - Víctor Martínez
   - Ernesto Tejeda
   - Carlos Lopez
+
+- `PureKarting <https://www.purekarting.com>`__:
+
+  - Cliff Kujala
 
 Maintainers
 -----------

--- a/mail_attach_existing_attachment_account/__manifest__.py
+++ b/mail_attach_existing_attachment_account/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "Thore Baden, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/mail",
     "category": "Social Network",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "license": "AGPL-3",
     "maintainers": ["chienandalu", "rafaelbn"],
     "depends": ["account", "mail_attach_existing_attachment"],

--- a/mail_attach_existing_attachment_account/readme/CONTRIBUTORS.md
+++ b/mail_attach_existing_attachment_account/readme/CONTRIBUTORS.md
@@ -3,3 +3,5 @@
   - Víctor Martínez
   - Ernesto Tejeda
   - Carlos Lopez
+- [PureKarting](https://www.purekarting.com):
+  - Cliff Kujala

--- a/mail_attach_existing_attachment_account/readme/DESCRIPTION.md
+++ b/mail_attach_existing_attachment_account/readme/DESCRIPTION.md
@@ -1,3 +1,7 @@
 This Module adds the mail_attach_existing_attachment feature to the
 account module, since there is a change in odoo 12.0, which adds a new
 mail wizard form to the account module
+
+The invoice's attachments are offered through the same foldable,
+multi-column picker the mail composer uses, so a long-lived invoice does
+not bury the wizard's own buttons under a column of checkboxes.

--- a/mail_attach_existing_attachment_account/static/description/index.html
+++ b/mail_attach_existing_attachment_account/static/description/index.html
@@ -378,6 +378,9 @@ ul.auto-toc {
 <p>This Module adds the mail_attach_existing_attachment feature to the
 account module, since there is a change in odoo 12.0, which adds a new
 mail wizard form to the account module</p>
+<p>The invoice’s attachments are offered through the same foldable,
+multi-column picker the mail composer uses, so a long-lived invoice does
+not bury the wizard’s own buttons under a column of checkboxes.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -425,6 +428,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Víctor Martínez</li>
 <li>Ernesto Tejeda</li>
 <li>Carlos Lopez</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://www.purekarting.com">PureKarting</a>:<ul>
+<li>Cliff Kujala</li>
 </ul>
 </li>
 </ul>

--- a/mail_attach_existing_attachment_account/wizard/account_move_send_wizard_view.xml
+++ b/mail_attach_existing_attachment_account/wizard/account_move_send_wizard_view.xml
@@ -12,7 +12,7 @@
             <xpath expr="//field[@name='mail_attachments_widget']" position="after">
                 <field
                     name="object_attachment_ids"
-                    widget="many2many_checkboxes"
+                    widget="attachment_checkbox_grid"
                     domain="[('res_model', '=', 'account.move'), ('res_id', '=', move_id)]"
                     invisible="not can_attach_attachment"
                     context="{'skip_res_field_check': True}"


### PR DESCRIPTION
## What

Offer the invoice's attachments through the same picker the mail composer gets in #243: folded by default, and laid out in as many columns as the send wizard is wide enough for. An invoice that has been mailed a few times otherwise buries the wizard's buttons under a column of checkboxes.

The account wizard's own "Attach a file" widget is deliberately left alone; only the existing-attachment picker changes.

## Depends on

#243, which adds the `attachment_checkbox_grid` widget in `mail_attach_existing_attachment`. This PR is a one-line widget swap on top of it.

## Test plan

- [x] Existing Python tests pass.
- [x] Open Send & Print on an invoice with several attachments: the picker is folded, and unfolds into a multi-column grid.
- [x] Tick one and send: it is still attached to the outgoing mail.
