### PR TITLE
[18.0][FIX] mail_composer_cc_bcc: email_cc type

### DIFF
--- a/mail_composer_cc_bcc/models/mail_mail.py
+++ b/mail_composer_cc_bcc/models/mail_mail.py
@@ -10,6 +10,7 @@ from odoo.addons.base.models.ir_mail_server import extract_rfc2822_addresses
 
 
 def format_emails(partners):
+    """List form, for the outgoing-dict slots (e.g. email_cc, email_to)."""
     return [tools.formataddr((p.name or "", p.email)) for p in partners if p.email]
 
 
@@ -18,6 +19,7 @@ def format_emails_raw(partners):
 
 
 def format_emails_str(partners):
+    """Comma-joined string form, for the mail.mail Char fields (e.g. email_cc)."""
     emails = format_emails(partners)
     return ", ".join(emails)
 
@@ -65,7 +67,7 @@ class MailMail(models.Model):
         partner_to = all_recipients - partners_cc_bcc
         email_to = format_emails(partner_to)
         email_to_raw = format_emails_raw(partner_to)
-        email_cc = format_emails_str(self.recipient_cc_ids)
+        email_cc = format_emails(self.recipient_cc_ids)
         email_bcc = [r.email for r in self.recipient_bcc_ids if r.email]
 
         # Collect recipients (RCPT TO) and update all emails


### PR DESCRIPTION
# Context

- Earlier, `mail_composer_cc_bcc` overrides `mail.mail._prepare_outgoing_list()` and was putting a comma-joined string into `email_to`, where native produces a list. 
- Hence, `mail_tracking` re-joins `email_to` with `COMMASPACE`, which mangles a value that is already a string.
- PR #54 fixed it by making `format_emails()` return the list form

In the same commit, in the same function, `email_cc` was changed in the opposite direction — from the list form to the joined-string form:

```python
 email_to = format_emails(partner_to)                 # list   — fixed by #54
-email_cc = format_emails(self.recipient_cc_ids)      # list   — was correct
+email_cc = format_emails_str(self.recipient_cc_ids)  # string — regression
```

So the commit made `email_to` a list and `email_cc` a string, in adjacent lines of the same dict.


# Solution
restoring the list form so `email_cc` matches `email_to` on the line directly