### PR TITLE
[18.0][FIX] mail_optional_follower_notification: Filter out followers

### DIFF
--- a/mail_optional_follower_notification/models/mail_thread.py
+++ b/mail_optional_follower_notification/models/mail_thread.py
@@ -20,5 +20,7 @@ class MailThread(models.AbstractModel):
                 if msg_vals
                 else message.sudo().partner_ids.ids
             )
-            recipient_data = [d for d in recipient_data if d["id"] in pids]
+            recipient_data = [
+                d for d in recipient_data if d["id"] in pids or not d.get("is_follower")
+            ]
         return recipient_data

--- a/mail_optional_follower_notification/tests/test_mail_optional_follower_notifications.py
+++ b/mail_optional_follower_notification/tests/test_mail_optional_follower_notifications.py
@@ -1,7 +1,11 @@
 # Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from unittest.mock import patch
+
 from odoo.tests.common import TransactionCase
+
+from odoo.addons.mail.models.mail_thread import MailThread
 
 
 class TestMailOptionalFollowernotifications(TransactionCase):
@@ -85,4 +89,57 @@ class TestMailOptionalFollowernotifications(TransactionCase):
         message = self._send_mail(self.partner_no_follower, notify_followers=False)
         self.assertEqual(
             message.notification_ids.mapped("res_partner_id"), self.partner_no_follower
+        )
+
+    def test_4_explicit_non_follower_not_in_partner_ids_is_kept(self):
+        """
+        Data:
+            One partner follower of partner_01, and another recipient
+            never added to partner_ids, but flagged as is_follower=False.
+        Test case:
+            Send message to the non follower partner and disable the
+            notification to followers.
+        Expected result:
+            The injected recipient is not a follower, so it must survive
+            the notify_followers=False filter even though it is not in
+            partner_ids. Only real followers should be stripped.
+        Note:
+            We are forced to patch because in core there is no way
+            to get is_follower=False for someone who isn't in pids.
+            However, this is interesting to test because it may happen
+            in combination with other modules, like 'mail_composer_cc_bcc'.
+        """
+        extra_partner = self.partner_no_follower.copy()
+        extra_partner.email = "extra@example.com"
+        original = MailThread._notify_get_recipients
+
+        def patched(self, message, msg_vals, **kwargs):
+            rdata = original(self, message, msg_vals, **kwargs)
+            rdata.append(
+                {
+                    "id": extra_partner.id,
+                    "active": True,
+                    "share": True,
+                    "notif": "email",
+                    "type": "customer",
+                    "is_follower": False,
+                    "lang": False,
+                    "uid": False,
+                }
+            )
+            return rdata
+
+        with patch.object(MailThread, "_notify_get_recipients", patched):
+            message = self._send_mail(self.partner_no_follower, notify_followers=False)
+
+        self.assertIn(
+            extra_partner,
+            message.notification_ids.mapped("res_partner_id"),
+            "An explicit non-follower recipient (not in partner_ids)"
+            "must not be stripped when notify_followers=False",
+        )
+        self.assertNotIn(
+            self.partner_follower,
+            message.notification_ids.mapped("res_partner_id"),
+            "A genuine follower must still be stripped when notify_followers=False",
         )


### PR DESCRIPTION
_notify_get_recipients used 'id in partner_ids' as a proxy for 'is a follower' when filtering recipients with notify_followers=False. This is safe only as long as every explicit recipient end up in partner_ids, which is the default behavior from core Odoo.

This assumption may be broken by other modules though. For instance, mail_composer_cc_bcc deliberately keeps cc/bcc recipients out of partner_ids and routes them through a separate channel instead, correctly flagging them as is_follower=False.

Filter on the is_follower flag every recipient dict already carries instead of partner_ids membership: it keeps the original intent (hide genuine followers) without collateral-damaging any explicit non-follower recipient.