### PR TITLE
[18.0][FIX] mail_composer_cc_bcc: Solve 'To' and '(B)Cc' overlap

### DIFF
--- a/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
+++ b/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
@@ -159,6 +159,42 @@ Test Template<br></p>""",
         expecting = self.partner_cc2 + self.partner_bcc
         self.assertEqual(composer.partner_bcc_ids, expecting)
 
+    def test_template_cc_overlapping_partner_ids(self):
+        """A partner who is both the resolved 'To' and listed in the
+        template's Cc must end up only in partner_ids, not
+        duplicated into partner_cc_ids.
+        """
+        self.test_record.email = "test-overlap@example.com"
+        tmpl_model = self.env["ir.model"].search([("model", "=", "res.partner")])
+        vals = {
+            "name": "Overlapping Cc Template",
+            "model_id": tmpl_model.id,
+            "subject": "Overlap",
+            "body_html": "<p>Hello</p>",
+            "email_cc": ", ".join(
+                tools.formataddr((p.name or "False", p.email or "False"))
+                for p in (self.partner_cc + self.test_record)
+            ),
+        }
+        overlap_tmpl = self.env["mail.template"].create(vals)
+
+        form = self.open_mail_composer_form()
+        composer = form.save()
+        form = Form(composer)
+        form.template_id = overlap_tmpl
+        composer = form.save()
+
+        self.assertEqual(
+            composer.partner_ids,
+            self.test_record,
+            "The To recipient must still be resolved normally",
+        )
+        self.assertEqual(
+            composer.partner_cc_ids,
+            self.partner_cc,
+            "The To recipient must not also be duplicated into Cc",
+        )
+
     def _set_parent_partner(self, parent, childs):
         # Ensure assign works even when other modules are installed
         # e.g. account: expect single record

--- a/mail_composer_cc_bcc/wizards/mail_compose_message.py
+++ b/mail_composer_cc_bcc/wizards/mail_compose_message.py
@@ -78,6 +78,8 @@ class MailComposeMessage(models.TransientModel):
             elif not composer.template_id:
                 composer.partner_cc_ids = self.env.company.default_partner_cc_ids
                 composer.partner_bcc_ids = self.env.company.default_partner_bcc_ids
+            composer.partner_cc_ids -= composer.partner_ids
+            composer.partner_bcc_ids -= composer.partner_ids
 
     @api.depends(
         "composition_mode", "model", "parent_id", "res_domain", "res_ids", "template_id"


### PR DESCRIPTION
A partner who is both the record's resolved "To" and present in the cc/bcc set was never deduplicated.
That overlap then reaches mail_mail._prepare_outgoing_list, whose formula (partner_to = all_recipients - partners_cc_bcc) excludes anyone found in partners_cc_bcc from "To".
If that partner was the only "To" recipient, the sent email ends up with a blank "To:" header.