### PR TITLE
[17.0][FIX] mail_notify_employee_leave: make absence tests time independent

### DIFF
--- a/mail_notify_employee_leave/tests/test_mail_notify_employee_leave.py
+++ b/mail_notify_employee_leave/tests/test_mail_notify_employee_leave.py
@@ -9,13 +9,14 @@ from freezegun import freeze_time
 from odoo import fields
 from odoo.tests.common import TransactionCase
 
-
 # ``is_absent`` is only true while the current time is inside the leave, and
 # ``hr.leave`` narrows a full day leave to the working schedule of the employee
-# (08:00-17:00 in the timezone of the company calendar). Freeze the clock inside
-# that window, otherwise the result depends on the time of the day at which the
-# tests happen to run.
-@freeze_time("2023-05-15 10:00:00")
+# (08:00-17:00 in the timezone of the company calendar). The tests that need an
+# absent employee freeze the clock inside that window, otherwise the result
+# depends on the time of the day at which they happen to run.
+WORKING_HOUR = "2023-05-15 10:00:00"
+
+
 class TestNotifyEmployeeLeave(TransactionCase):
     @classmethod
     def setUpClass(cls):
@@ -58,16 +59,15 @@ class TestNotifyEmployeeLeave(TransactionCase):
 
         cls.record = cls.env["res.partner"].create({"name": "Test Record"})
 
-    @classmethod
-    def _create_validated_leave(cls):
+    def _create_validated_leave(self):
         today = fields.Date.today()
         leave = (
-            cls.env["hr.leave"]
+            self.env["hr.leave"]
             .with_context(skip_absence_notification=True)
             .create(
                 {
-                    "holiday_status_id": cls.leave_type.id,
-                    "employee_id": cls.employee.id,
+                    "holiday_status_id": self.leave_type.id,
+                    "employee_id": self.employee.id,
                     "date_from": datetime.combine(today, time(0, 0, 0)),
                     "date_to": datetime.combine(today, time(23, 59, 59)),
                 }
@@ -83,6 +83,7 @@ class TestNotifyEmployeeLeave(TransactionCase):
 
         self.assertNotIn(self.user, self.employee.absence_notified_user_ids)
 
+    @freeze_time(WORKING_HOUR)
     def test_notify_when_user_absent(self):
         self._create_validated_leave()
 
@@ -93,6 +94,7 @@ class TestNotifyEmployeeLeave(TransactionCase):
         self.assertIn(self.user, self.employee.absence_notified_user_ids)
         self.assertEqual(self.employee.absence_notified_date, fields.Date.today())
 
+    @freeze_time(WORKING_HOUR)
     def test_only_one_notification_per_day(self):
         self._create_validated_leave()
 

--- a/mail_notify_employee_leave/tests/test_mail_notify_employee_leave.py
+++ b/mail_notify_employee_leave/tests/test_mail_notify_employee_leave.py
@@ -4,10 +4,18 @@
 
 from datetime import datetime, time
 
+from freezegun import freeze_time
+
 from odoo import fields
 from odoo.tests.common import TransactionCase
 
 
+# ``is_absent`` is only true while the current time is inside the leave, and
+# ``hr.leave`` narrows a full day leave to the working schedule of the employee
+# (08:00-17:00 in the timezone of the company calendar). Freeze the clock inside
+# that window, otherwise the result depends on the time of the day at which the
+# tests happen to run.
+@freeze_time("2023-05-15 10:00:00")
 class TestNotifyEmployeeLeave(TransactionCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
`TestNotifyEmployeeLeave` fails depending on the time of day the CI runs.

`_create_validated_leave()` creates a full-day leave (00:00-23:59), but `hr.leave`
narrows it to the working schedule of the employee, so with the standard company
calendar (08:00-17:00 Europe/Brussels) the stored leave is 06:00-15:00 UTC. The
tests then rely on `employee.is_absent`, which is computed as
`date_from <= now <= date_to`, so they only pass while the runner clock happens
to be inside that window.

Reproduced locally: with the clock frozen at 20:00 the two tests fail exactly as
in CI; inside the window they pass. Recent runs match: the 17.0 post-merge run at
07:10 UTC was green, PR runs at 19:20 and 21:02 UTC were red (e.g. #258).

Fix: freeze the clock at a working hour of a working day, so the tests no longer
depend on when they run.
