### PR TITLE
[18.0] [FIX] mail_debrand: debrand auth_signup emails

### DIFF
--- a/mail_debrand/README.rst
+++ b/mail_debrand/README.rst
@@ -36,6 +36,25 @@ branding, specifically the 'Powered by Odoo'
 .. contents::
    :local:
 
+Configuration
+=============
+
+By default the standalone mentions of the brand that the Odoo templates
+write as prose ("Welcome to Odoo", "Enjoy Odoo!", "A password reset was
+requested for the Odoo account...") are replaced by the name of the
+company, so the sentences still read well.
+
+This can be changed with the ``mail_debrand.brand_replacement`` system
+parameter (Settings > Technical > System Parameters):
+
+- unset (default): the mentions are replaced by the company name.
+- any other value: the mentions are replaced by that value.
+- ``False``: the mentions are left untouched and only the links to
+  odoo.com are removed.
+
+URLs, e-mail addresses and identifiers such as ``odoo.com``,
+``odoobot@example.com`` or ``OdooBot`` are never modified.
+
 Usage
 =====
 
@@ -50,9 +69,9 @@ Known issues / Roadmap
 
 Known issues:
 
-- Not all branding is removed from auth_signup's invitation email
-  because it is a longer, more complex snippet of HTML. Only the line
-  containing the link to Odoo.com is removed.
+- Only the branding shipped by the templates is debranded. Data stored
+  in the records themselves is never modified, so a user literally named
+  ``OdooBot`` keeps that name in the mails that mention it.
 
 Changelog
 =========
@@ -101,6 +120,7 @@ Contributors
   - João Marques
 
 - Stefan Rijnhart stefan@opener.amsterdam
+- `Nimarosa <https://github.com/nimarosa>`__
 
 Maintainers
 -----------

--- a/mail_debrand/__manifest__.py
+++ b/mail_debrand/__manifest__.py
@@ -8,11 +8,11 @@
 {
     "name": "Mail Debrand",
     "summary": """Remove Odoo branding in sent emails
-    Removes anchor <a href odoo.com togheder with it's parent
-    ( for powerd by) form all the templates
-    removes any 'odoo' that are in tempalte texts > 20characters
+    Removes the anchors <a href odoo.com together with their parent
+    (the "powered by" line) from all the templates, and replaces the
+    remaining standalone mentions of the brand by the company name
     """,
-    "version": "18.0.1.0.1",
+    "version": "18.0.1.1.0",
     "category": "Social Network",
     "website": "https://github.com/OCA/mail",
     "author": """Tecnativa, ForgeFlow, Onestein, Sodexis, Nexterp Romania,

--- a/mail_debrand/models/mail_render_mixin.py
+++ b/mail_debrand/models/mail_render_mixin.py
@@ -68,11 +68,7 @@ class MailRenderMixin(models.AbstractModel):
         chunks[::2] = [
             BRAND_MENTION_RE.sub(replacement, chunk) for chunk in chunks[::2]
         ]
-        value = "".join(chunks)
-        if not replacement:
-            # Avoid the double spaces left behind by an empty replacement.
-            value = re.sub(r"[ \t]{2,}", " ", value)
-        return value
+        return "".join(chunks)
 
     def _remove_odoo_anchor(self, elem):
         """Drop an ``odoo.com`` anchor and the promotional text around it."""

--- a/mail_debrand/models/mail_render_mixin.py
+++ b/mail_debrand/models/mail_render_mixin.py
@@ -10,9 +10,92 @@ from markupsafe import Markup
 
 from odoo import api, models
 
+BODY_PLACEHOLDER = "<body_msg></body_msg>"
+# Match the brand as a standalone word only. The look-behind and the
+# look-ahead keep domain names (``odoo.com``, ``www.odoo.sh``), e-mail
+# addresses, paths and longer identifiers (``OdooBot``) untouched, so only
+# the branding written as prose is replaced.
+BRAND_MENTION_RE = re.compile(
+    r"(?<![\w./@-])odoo(?![\w@/]|[.-]\w)", flags=re.IGNORECASE
+)
+# ``re.split`` on this keeps the HTML tags in the resulting list, so the
+# replacement can be applied to the text nodes only, never to an attribute.
+HTML_TAG_RE = re.compile(r"(<[^>]*>)")
+
 
 class MailRenderMixin(models.AbstractModel):
     _inherit = "mail.render.mixin"
+
+    @api.model
+    def _get_debrand_replacement(self):
+        """Text that replaces the standalone brand mentions.
+
+        It defaults to the name of the current company, which reads naturally
+        in the sentences shipped by Odoo ("Welcome to Odoo", "Enjoy Odoo!",
+        "A password reset was requested for the Odoo account..."). It can be
+        overridden with the ``mail_debrand.brand_replacement`` configuration
+        parameter, and setting that parameter to ``False`` disables the
+        replacement altogether.
+
+        :return: the replacement string, or ``None`` when disabled.
+        """
+        param = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("mail_debrand.brand_replacement", default=None)
+        )
+        if param is None:
+            return self.env.company.name or ""
+        # ``value`` is a required field on ir.config_parameter, so the way to
+        # disable the feature is the "False" string.
+        if param.strip().lower() in ("false", "none"):
+            return None
+        return param
+
+    def remove_odoo_mentions(self, value):
+        """Replace the brand mentions left in the text once the links are gone.
+
+        Removing the ``odoo.com`` anchors is not enough for the templates that
+        talk about the brand in plain words, such as the ones from
+        ``auth_signup``. Only text nodes are processed, so URLs, e-mail
+        addresses and any other attribute keep their value.
+        """
+        replacement = self._get_debrand_replacement()
+        if replacement is None or not BRAND_MENTION_RE.search(value):
+            return value
+        chunks = HTML_TAG_RE.split(value)
+        # Even indexes are text nodes, odd ones are the HTML tags themselves.
+        chunks[::2] = [
+            BRAND_MENTION_RE.sub(replacement, chunk) for chunk in chunks[::2]
+        ]
+        value = "".join(chunks)
+        if not replacement:
+            # Avoid the double spaces left behind by an empty replacement.
+            value = re.sub(r"[ \t]{2,}", " ", value)
+        return value
+
+    def _remove_odoo_anchor(self, elem):
+        """Drop an ``odoo.com`` anchor and the promotional text around it."""
+        parent = elem.getparent()
+        # Remove "Powered by", "using" etc.
+        previous = elem.getprevious()
+        if previous is not None:
+            previous.tail = etree.CDATA("&nbsp;")
+            # The link is usually the last line of a longer promotional block
+            # (auth_signup's invitation mail). Drop the preceding text runs
+            # that talk about the brand too, stopping at the first one that
+            # belongs to the actual message.
+            sibling = previous.getprevious()
+            while sibling is not None:
+                tail = sibling.tail or ""
+                if tail.strip():
+                    if not BRAND_MENTION_RE.search(tail):
+                        break
+                    sibling.tail = None
+                sibling = sibling.getprevious()
+        elif parent.text:
+            parent.text = etree.CDATA("&nbsp;")
+        parent.remove(elem)
 
     def remove_href_odoo(self, value, to_keep=None):
         if len(value) < 20:
@@ -29,27 +112,21 @@ class MailRenderMixin(models.AbstractModel):
             r"<a\s(.*)dev\.odoo\.com", value, flags=re.IGNORECASE
         )
         has_odoo_link = re.search(r"<a\s(.*)odoo\.com", value, flags=re.IGNORECASE)
+        # We don't want to change what was explicitly added in the message body,
+        # so we will only change what is before and after it.
+        if to_keep:
+            value = value.replace(to_keep, BODY_PLACEHOLDER)
         if has_odoo_link and not has_dev_odoo_link:
-            # We don't want to change what was explicitly added in the message body,
-            # so we will only change what is before and after it.
-            if to_keep:
-                value = value.replace(to_keep, "<body_msg></body_msg>")
             tree = html.fromstring(value)
             odoo_anchors = tree.xpath('//a[contains(@href,"odoo.com")]')
             for elem in odoo_anchors:
-                parent = elem.getparent()
-                # Remove "Powered by", "using" etc.
-                previous = elem.getprevious()
-                if previous is not None:
-                    previous.tail = etree.CDATA("&nbsp;")
-                elif parent.text:
-                    parent.text = etree.CDATA("&nbsp;")
-                parent.remove(elem)
+                self._remove_odoo_anchor(elem)
             value = etree.tostring(
                 tree, pretty_print=True, method="html", encoding="unicode"
             )
-            if to_keep:
-                value = value.replace("<body_msg></body_msg>", to_keep)
+        value = self.remove_odoo_mentions(value)
+        if to_keep:
+            value = value.replace(BODY_PLACEHOLDER, to_keep)
         if back_to_bytes:
             value = value.encode()
         elif back_to_markup:

--- a/mail_debrand/readme/CONFIGURE.md
+++ b/mail_debrand/readme/CONFIGURE.md
@@ -1,0 +1,15 @@
+By default the standalone mentions of the brand that the Odoo templates
+write as prose ("Welcome to Odoo", "Enjoy Odoo!", "A password reset was
+requested for the Odoo account...") are replaced by the name of the
+company, so the sentences still read well.
+
+This can be changed with the `mail_debrand.brand_replacement` system
+parameter (Settings \> Technical \> System Parameters):
+
+- unset (default): the mentions are replaced by the company name.
+- any other value: the mentions are replaced by that value.
+- `False`: the mentions are left untouched and only the links to
+  odoo.com are removed.
+
+URLs, e-mail addresses and identifiers such as `odoo.com`,
+`odoobot@example.com` or `OdooBot` are never modified.

--- a/mail_debrand/readme/CONTRIBUTORS.md
+++ b/mail_debrand/readme/CONTRIBUTORS.md
@@ -4,3 +4,4 @@
     -   Pedro M. Baeza
     -   João Marques
 - Stefan Rijnhart <stefan@opener.amsterdam>
+- [Nimarosa](https://github.com/nimarosa)

--- a/mail_debrand/readme/ROADMAP.md
+++ b/mail_debrand/readme/ROADMAP.md
@@ -1,5 +1,5 @@
 Known issues:
 
-- Not all branding is removed from auth_signup's invitation email
-  because it is a longer, more complex snippet of HTML. Only the line
-  containing the link to Odoo.com is removed.
+- Only the branding shipped by the templates is debranded. Data stored in
+  the records themselves is never modified, so a user literally named
+  `OdooBot` keeps that name in the mails that mention it.

--- a/mail_debrand/static/description/index.html
+++ b/mail_debrand/static/description/index.html
@@ -375,24 +375,42 @@ branding, specifically the ‘Powered by Odoo’</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#changelog" id="toc-entry-3">Changelog</a><ul>
-<li><a class="reference internal" href="#section-1" id="toc-entry-4">15.0.1.2.3 (2022-07-19)</a></li>
-<li><a class="reference internal" href="#section-2" id="toc-entry-5">12.0.1.0.0 (2018-11-06)</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-3">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#changelog" id="toc-entry-4">Changelog</a><ul>
+<li><a class="reference internal" href="#section-1" id="toc-entry-5">15.0.1.2.3 (2022-07-19)</a></li>
+<li><a class="reference internal" href="#section-2" id="toc-entry-6">12.0.1.0.0 (2018-11-06)</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-6">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-7">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-8">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-9">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-10">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-7">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-8">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-9">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-10">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-11">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
+<p>By default the standalone mentions of the brand that the Odoo templates
+write as prose (“Welcome to Odoo”, “Enjoy Odoo!”, “A password reset was
+requested for the Odoo account…”) are replaced by the name of the
+company, so the sentences still read well.</p>
+<p>This can be changed with the <tt class="docutils literal">mail_debrand.brand_replacement</tt> system
+parameter (Settings &gt; Technical &gt; System Parameters):</p>
+<ul class="simple">
+<li>unset (default): the mentions are replaced by the company name.</li>
+<li>any other value: the mentions are replaced by that value.</li>
+<li><tt class="docutils literal">False</tt>: the mentions are left untouched and only the links to
+odoo.com are removed.</li>
+</ul>
+<p>URLs, e-mail addresses and identifiers such as <tt class="docutils literal">odoo.com</tt>,
+<tt class="docutils literal">odoobot&#64;example.com</tt> or <tt class="docutils literal">OdooBot</tt> are never modified.</p>
+</div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
 <p>To use this module, you need to:</p>
 <ul class="simple">
 <li>Install it.</li>
@@ -401,32 +419,32 @@ branding, specifically the ‘Powered by Odoo’</p>
 </ul>
 </div>
 <div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
 <p>Known issues:</p>
 <ul class="simple">
-<li>Not all branding is removed from auth_signup’s invitation email
-because it is a longer, more complex snippet of HTML. Only the line
-containing the link to Odoo.com is removed.</li>
+<li>Only the branding shipped by the templates is debranded. Data stored
+in the records themselves is never modified, so a user literally named
+<tt class="docutils literal">OdooBot</tt> keeps that name in the mails that mention it.</li>
 </ul>
 </div>
 <div class="section" id="changelog">
-<h1><a class="toc-backref" href="#toc-entry-3">Changelog</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Changelog</a></h1>
 <div class="section" id="section-1">
-<h2><a class="toc-backref" href="#toc-entry-4">15.0.1.2.3 (2022-07-19)</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">15.0.1.2.3 (2022-07-19)</a></h2>
 <ul class="simple">
 <li>[FIX] <a class="reference external" href="https://github.com/OCA/social/issues/915">https://github.com/OCA/social/issues/915</a></li>
 <li>[FIX] <a class="reference external" href="https://github.com/OCA/social/issues/936">https://github.com/OCA/social/issues/936</a></li>
 </ul>
 </div>
 <div class="section" id="section-2">
-<h2><a class="toc-backref" href="#toc-entry-5">12.0.1.0.0 (2018-11-06)</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">12.0.1.0.0 (2018-11-06)</a></h2>
 <ul class="simple">
 <li>[NEW] Initial V12 version. Complete rewrite from v11.</li>
 </ul>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-6">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-7">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/mail/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -434,9 +452,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-7">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-8">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-8">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-9">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 <li>ForgeFlow</li>
@@ -446,7 +464,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-9">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-10">Contributors</a></h2>
 <ul class="simple">
 <li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;forgeflow.com">lois.rilo&#64;forgeflow.com</a>&gt;</li>
 <li>Graeme Gellatly &lt;<a class="reference external" href="mailto:graeme&#64;o4sb.com">graeme&#64;o4sb.com</a>&gt;</li>
@@ -456,10 +474,11 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </li>
 <li>Stefan Rijnhart <a class="reference external" href="mailto:stefan&#64;opener.amsterdam">stefan&#64;opener.amsterdam</a></li>
+<li><a class="reference external" href="https://github.com/nimarosa">Nimarosa</a></li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-10">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-11">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/mail_debrand/tests/test_mail_debrand.py
+++ b/mail_debrand/tests/test_mail_debrand.py
@@ -77,6 +77,46 @@ class TestMailDebrand(common.TransactionCase):
             "Aangeboden door",
         )
 
+    def test_remove_odoo_mentions(self):
+        """Standalone brand mentions are replaced by the company name"""
+        mixin = self.env["mail.render.mixin"]
+        company = self.env.company.name
+        self.assertEqual(
+            mixin.remove_odoo_mentions("<p>Welcome to Odoo. Enjoy Odoo!</p>"),
+            f"<p>Welcome to {company}. Enjoy {company}!</p>",
+        )
+
+    def test_remove_odoo_mentions_keeps_technical_values(self):
+        """URLs, e-mail addresses and identifiers are never touched"""
+        mixin = self.env["mail.render.mixin"]
+        for value in (
+            '<a href="https://www.odoo.com?utm_source=db">Link</a>',
+            "<p>Contact odoobot@example.com or odoo-support@example.com</p>",
+            "<p>OdooBot created this record</p>",
+            '<img src="/web/static/img/odoo-logo.png"/>',
+            # A database named "odoo" ends up in the sign-in links
+            '<a href="http://localhost:8069/web/login?db=odoo">Log in</a>',
+        ):
+            self.assertEqual(mixin.remove_odoo_mentions(value), value)
+
+    def test_remove_odoo_mentions_custom_replacement(self):
+        self.env["ir.config_parameter"].sudo().set_param(
+            "mail_debrand.brand_replacement", "Acme"
+        )
+        self.assertEqual(
+            self.env["mail.render.mixin"].remove_odoo_mentions("<p>Enjoy Odoo!</p>"),
+            "<p>Enjoy Acme!</p>",
+        )
+
+    def test_remove_odoo_mentions_disabled(self):
+        self.env["ir.config_parameter"].sudo().set_param(
+            "mail_debrand.brand_replacement", "False"
+        )
+        value = "<p>Enjoy Odoo!</p>"
+        self.assertEqual(
+            self.env["mail.render.mixin"].remove_odoo_mentions(value), value
+        )
+
     def test_body_intact(self):
         """The message body should never be changed"""
         MailMessage = self.env["mail.mail"]

--- a/mail_debrand/tests/test_mail_debrand.py
+++ b/mail_debrand/tests/test_mail_debrand.py
@@ -99,6 +99,16 @@ class TestMailDebrand(common.TransactionCase):
         ):
             self.assertEqual(mixin.remove_odoo_mentions(value), value)
 
+    def test_dev_odoo_link_disables_debranding(self):
+        """A dev.odoo.com link marks the mail as one to leave alone"""
+        value = (
+            '<p>Ticket on <a href="https://dev.odoo.com/1">dev</a>, '
+            'released by <a href="https://www.odoo.com">Odoo</a></p>'
+        )
+        result = self.env["mail.render.mixin"].remove_href_odoo(value)
+        self.assertIn('href="https://www.odoo.com"', result)
+        self.assertIn('href="https://dev.odoo.com/1"', result)
+
     def test_remove_odoo_mentions_custom_replacement(self):
         self.env["ir.config_parameter"].sudo().set_param(
             "mail_debrand.brand_replacement", "Acme"

--- a/mail_debrand/tests/test_mail_debrand_signup.py
+++ b/mail_debrand/tests/test_mail_debrand_signup.py
@@ -1,5 +1,10 @@
 from odoo.tests import TransactionCase, tagged
 
+from odoo.addons.mail_debrand.models.mail_render_mixin import (
+    BRAND_MENTION_RE,
+    HTML_TAG_RE,
+)
+
 
 @tagged("-at_install", "post_install")
 class TestMailDebrandSignup(TransactionCase):
@@ -7,6 +12,19 @@ class TestMailDebrandSignup(TransactionCase):
         module = self.env["ir.module.module"].search([("name", "=", "auth_signup")])
         self.assertTrue(module)
         return module.state == "installed"
+
+    def _assert_debranded(self, body):
+        """No standalone brand mention is left in the visible text.
+
+        Only the text nodes are checked, exactly like the debranding itself:
+        the URLs are none of its business, and a database literally named
+        "odoo" would otherwise make this fail on its own sign-in link.
+        """
+        for text in HTML_TAG_RE.split(body)[::2]:
+            self.assertFalse(
+                BRAND_MENTION_RE.search(text),
+                f"Brand mention left in the rendered mail: {text}",
+            )
 
     def test_debrand_auth_signup_set_password_email(self):
         if not self._has_module():
@@ -17,12 +35,70 @@ class TestMailDebrandSignup(TransactionCase):
         self.assertIn("www.odoo.com", template.body_html)
         self.assertIn("Accept invitation", template.body_html)
         self.assertIn("to discover the tool", template.body_html)
+        self.assertIn("Never heard of Odoo?", template.body_html)
 
         mail_id = template.send_mail(self.env.user.id)
-        body = self.env["mail.mail"].browse(mail_id).body_html
+        mail = self.env["mail.mail"].browse(mail_id)
+        body = mail.body_html
 
         # The essential button is preserved
         self.assertIn("Accept invitation", body)
-        # But at least part of the branding was removed
+        # The branding is gone, links and prose alike
         self.assertNotIn("www.odoo.com", body)
         self.assertNotIn("to discover the tool", body)
+        # The promotional block that came with the removed link goes with it
+        self.assertNotIn("Never heard of", body)
+        self._assert_debranded(body)
+        # ... and so does the branding of the subject
+        self._assert_debranded(mail.subject)
+        # The company name took its place, so the sentences still read well
+        self.assertIn(f"Welcome to {self.env.company.name}", body)
+
+    def test_debrand_auth_signup_reset_password_email(self):
+        """The reset password mail is rendered from a qweb view, not a template."""
+        if not self._has_module():
+            return
+        view = self.env.ref("auth_signup.reset_password_email")
+        user = self.env.user
+        # Same call as auth_signup's ``_action_reset_password``
+        body = self.env["mail.render.mixin"]._render_template(
+            view,
+            model="res.users",
+            res_ids=user.ids,
+            engine="qweb_view",
+            options={"post_process": True},
+        )[user.id]
+        mail = (
+            self.env["mail.mail"]
+            .sudo()
+            .create(
+                {
+                    "subject": "Password reset",
+                    "email_from": "noreply@example.com",
+                    "email_to": "user@example.com",
+                    "body_html": body,
+                }
+            )
+        )
+        outgoing_body = mail._prepare_outgoing_body()
+        # The action link is preserved
+        self.assertIn("Change password", outgoing_body)
+        self._assert_debranded(outgoing_body)
+
+    def test_record_data_is_not_debranded(self):
+        """Only the branding is replaced, never the data of the records."""
+        if not self._has_module():
+            return
+        user = self.env["res.users"].create(
+            {
+                "name": "OdooBot Sanchez",
+                "login": "odoobot.sanchez@example.com",
+                "email": "odoobot.sanchez@example.com",
+            }
+        )
+        template = self.env.ref("auth_signup.set_password_email")
+        mail_id = template.send_mail(user.id)
+        body = self.env["mail.mail"].browse(mail_id).body_html
+        self.assertIn("OdooBot Sanchez", body)
+        self.assertIn("odoobot.sanchez@example.com", body)
+        self._assert_debranded(body)


### PR DESCRIPTION
## What was broken

`mail_debrand`'s own README lists it as a known issue:

> Not all branding is removed from auth_signup's invitation email because it is a longer, more complex snippet of HTML. Only the line containing the link to Odoo.com is removed.

Rendering the two `auth_signup` mails on 18.0 with `mail_debrand` installed (text extracted from the actual outgoing body) gives:

**New user invitation** (`auth_signup.set_password_email`, sent by `_action_reset_password` in create mode)

> Welcome to **Odoo** — Dear Marc Demo, You have been invited by OdooBot of YourCompany to connect on **Odoo**. [Accept invitation] This link will remain valid during 6 days. Your **Odoo** domain is: … Never heard of **Odoo**? It's an all-in-one business software loved by 7+ million users. It will considerably improve your experience at work and increase your productivity. Enjoy **Odoo**!

…with the subject `OdooBot from YourCompany invites you to connect to Odoo`.

**Password reset** (`auth_signup.reset_password_email`)

> A password reset was requested for the **Odoo** account linked to this email.

## Root cause

The hook is not being bypassed — both mails do go through `mail.render.mixin._render_template` (the reset password one via `engine="qweb_view"`, the invitation via `mail.template.send_mail`), and `mail.mail._prepare_outgoing_body` runs on top. The problem is what `remove_href_odoo` does: it only looks for `//a[contains(@href,"odoo.com")]`, removes those anchors and blanks the text node immediately before them. That is enough for the `Powered by <a>Odoo</a>` footer of `mail_notification_layout`, but `auth_signup`'s templates write the brand as **prose**, with no link attached, so every one of those mentions survived. The subject is not HTML at all, so nothing was ever removed from it.

Note the module's own manifest summary has claimed since v12 that it "removes any 'odoo' that are in template texts > 20 characters" — that behaviour never actually existed in the code.

## The fix

1. **`remove_odoo_mentions`** replaces the remaining standalone mentions of the brand by the name of the company (`Welcome to Acme`, `Enjoy Acme!`, `A password reset was requested for the Acme account…`), which keeps the sentences readable instead of leaving holes in them. It runs on text nodes only — the value is split on HTML tags and only the text chunks are substituted — so `href`, `src` and any other attribute keeps its value. It works on plain strings too, which is what fixes the subject.

   Word boundaries are strict: `(?<![\w./@-])odoo(?![\w@/]|[.-]\w)`. `odoo.com`, `www.odoo.sh`, `odoobot@example.com`, `/web/static/img/odoo-logo.png` and `OdooBot` are all left alone, so **only the branding is debranded, never the data of the records**.

   Configurable with the `mail_debrand.brand_replacement` system parameter: unset → the company name, any value → that value, `False` → feature off (only the links are removed, i.e. the previous behaviour).

2. **The promotional block that comes with a removed link is dropped too.** When an `odoo.com` anchor is removed, the preceding sibling text runs are also cleared while they mention the brand, stopping at the first one that belongs to the actual message. That is what removes `Never heard of Odoo? It's an all-in-one business software loved by 7+ million users. …` from the invitation — a sentence that would be plainly false if it were merely rebranded.

3. The `to_keep` protection (the user's own message body) now wraps **both** passes, so a message that legitimately talks about Odoo is still never modified.

Result, same two mails:

> Welcome to Acme — Dear Marc Demo, You have been invited by OdooBot of Acme to connect on Acme. [Accept invitation] This link will remain valid during 6 days. Your Acme domain is: … Enjoy Acme!

> A password reset was requested for the Acme account linked to this email.

`OdooBot` above is the inviting user's *name*, a record value; the module deliberately does not rewrite it, and the README's known-issues section now says so instead of the auth_signup entry.

## Tests

`mail_debrand/tests/`, 14 tests, all green on a real 18.0 database:

- `test_debrand_auth_signup_set_password_email` — extended: the `Accept invitation` button survives, `www.odoo.com`, `to discover the tool` and the whole `Never heard of…` block are gone, **no standalone brand mention is left in the body or in the subject**, and `Welcome to <company>` is there.
- `test_debrand_auth_signup_reset_password_email` — new, exercises the `qweb_view` render + `_prepare_outgoing_body` path exactly as `_action_reset_password` does; `Change password` survives, no brand mention left.
- `test_record_data_is_not_debranded` — new, a user named `OdooBot Sanchez` with `odoobot.sanchez@example.com` keeps both in the mail.
- `test_remove_odoo_mentions`, `…_keeps_technical_values`, `…_custom_replacement`, `…_disabled` — new unit tests for the replacement itself.

Also verified end to end on a dev stack: the mails actually delivered to the SMTP catcher (invitation on user creation and `action_reset_password()`) contain no `odoo.com` and no standalone brand mention.

Closes the `auth_signup` known issue listed in the module's ROADMAP.
