### PR TITLE
[18.0][FIX] mail_tracking: Retry wizard was empty when reopened

### DIFF
--- a/mail_tracking/models/mail_message.py
+++ b/mail_tracking/models/mail_message.py
@@ -305,6 +305,25 @@ class MailMessage(models.Model):
         ]
         return res
 
+    def _message_notifications_to_store(self, store: Store):
+        """Refresh the tracking data along with the notification statuses.
+
+        Core pushes this to the web client whenever the notifications of a
+        message change (a delivery failure, a resend...), so it's the right
+        place to keep the failed messages widget up to date.
+        """
+        res = super()._message_notifications_to_store(store)
+        for message in self.filtered("mail_tracking_ids"):
+            store.add(
+                message,
+                {
+                    "partner_trackings": message.tracking_status(),
+                    "mail_tracking_needs_action": message.mail_tracking_needs_action,
+                    "is_failed_message": message.is_failed_message,
+                },
+            )
+        return res
+
     def _extras_to_store(self, store: Store, format_reply):
         res = super()._extras_to_store(store, format_reply=format_reply)
         for message in self:

--- a/mail_tracking/wizards/mail_resend_message.py
+++ b/mail_tracking/wizards/mail_resend_message.py
@@ -3,9 +3,54 @@
 
 from odoo import Command, api, models
 
+# Map between the error types stored in mail.tracking.email and the failure
+# types understood by mail.notification
+TRACKING_FAILURE_TYPES = {
+    "no_recipient": "mail_email_missing",
+    "MailDeliveryException": "mail_smtp",
+    "SMTPServerDisconnected": "mail_smtp",
+    "SMTPSenderRefused": "mail_smtp",
+    "SMTPRecipientsRefused": "mail_email_invalid",
+}
+
 
 class MailResendMessage(models.TransientModel):
     _inherit = "mail.resend.message"
+
+    def _tracking_notification_get(self, mail_message, tracking):
+        """Return the notification of the tracking recipient, creating it if missing.
+
+        ``mail.resend.partner`` requires a ``mail.notification``, but plenty of
+        failed trackings have none: messages sent outside of the notification
+        system (``email_outgoing`` ones, like invoices sent by mail) never get
+        notifications, and extra recipients (Cc, raw ``email_to``...) aren't
+        notified either. Creating the missing notification is what allows those
+        recipients to be resent at all.
+        """
+        if not tracking.partner_id:
+            # An email notification can't exist without a partner
+            return self.env["mail.notification"]
+        notification = mail_message.notification_ids.filtered(
+            lambda x, tracking=tracking: x.res_partner_id == tracking.partner_id
+        )[:1]
+        if notification:
+            return notification
+        return (
+            self.env["mail.notification"]
+            .sudo()
+            .create(
+                {
+                    "mail_message_id": mail_message.id,
+                    "res_partner_id": tracking.partner_id.id,
+                    "notification_type": "email",
+                    "notification_status": "exception",
+                    "failure_type": TRACKING_FAILURE_TYPES.get(
+                        tracking.error_type, "unknown"
+                    ),
+                    "failure_reason": tracking.error_description,
+                }
+            )
+        )
 
     @api.model
     def default_get(self, fields):
@@ -19,17 +64,21 @@ class MailResendMessage(models.TransientModel):
             lambda x: x.state in failed_states
         )
         if tracking_ids:
+            # Recipients that mail.notification already prepared in super()
+            prepared_partners = mail_message.notification_ids.filtered(
+                lambda x: x.notification_type == "email"
+                and x.notification_status in ("exception", "bounce")
+            ).res_partner_id
             partner_values = []
             for tracking in tracking_ids:
-                notification = mail_message.notification_ids.filtered(
-                    lambda x, tracking=tracking: x.res_partner_id == tracking.partner_id
-                )
-                existing_resend_partner = self.env["mail.resend.partner"].search(
-                    [("notification_id", "=", notification.id)]
-                )
-                if existing_resend_partner:
+                if tracking.partner_id in prepared_partners:
+                    # Create only resends that mail.notification didn't prepare
                     continue
-                # Create only resends that mail.notification didn't prepare already
+                notification = self._tracking_notification_get(mail_message, tracking)
+                if not notification:
+                    # Nothing to resend to: recipient without partner
+                    continue
+                prepared_partners |= notification.res_partner_id
                 partner_values.append(
                     {
                         "notification_id": notification.id,


### PR DESCRIPTION
Reopening the resend wizard on a failed message showed no recipients at all, leaving no way to retry the delivery.

The wizard deduplicated its own lines with a search over the whole mail.resend.partner table instead of scoping it to the current wizard. Those transient records survive between openings until the vacuum removes them, so the second time the wizard was opened the search matched the records created by the first one and every tracking was skipped.

cc @Tecnativa

ping @pedrobaeza @christian-ramos-tecnativa 