### PR TITLE
[18.0][FIX] mail_composer_cc_bcc: keep the "View <record>" button for internal user recipients

### DIFF
--- a/mail_composer_cc_bcc/models/mail_thread.py
+++ b/mail_composer_cc_bcc/models/mail_thread.py
@@ -61,8 +61,6 @@ class MailThread(models.AbstractModel):
         skip_adding_cc_bcc = context.get("skip_adding_cc_bcc", False)
         if not is_from_composer or skip_adding_cc_bcc:
             return rdata
-        for pdata in rdata:
-            pdata["type"] = "customer"
         partners_cc_bcc = context.get("partner_cc_ids", ResPartner)
         partners_cc_bcc += context.get("partner_bcc_ids", ResPartner)
         msg_sudo = message.sudo()
@@ -85,13 +83,12 @@ class MailThread(models.AbstractModel):
                     "notif"
                 ):  # notif is False, has no user, is therefore customer
                     notif = "email"
-                msg_type = "customer"
                 pdata = {
                     "id": data.get("id"),
                     "active": data.get("active"),
                     "share": data.get("share"),
                     "notif": data.get("notif") and data.get("notif") or notif,
-                    "type": msg_type,
+                    "type": data.get("type") or "customer",
                     "is_follower": data.get("is_follower"),
                     "lang": data.get("lang"),
                     "uid": False,
@@ -109,20 +106,28 @@ class MailThread(models.AbstractModel):
         skip_adding_cc_bcc = self.env.context.get("skip_adding_cc_bcc", False)
         if not is_from_composer or skip_adding_cc_bcc:
             return res
-        ids = []
-        customer_data = None
+        user_data = None
+        other_groups = []
         for rcpt_data in res:
-            if rcpt_data["notification_group_name"] == "customer":
-                customer_data = rcpt_data
+            if rcpt_data["notification_group_name"] == "user":
+                user_data = rcpt_data
             else:
-                ids += rcpt_data["recipients"]
-        if not customer_data:
-            customer_data = res[0]
-            customer_data["notification_group_name"] = "customer"
-            customer_data["recipients"] = ids
-        else:
-            customer_data["recipients"] += ids
-        return [customer_data]
+                other_groups.append(rcpt_data)
+        if not other_groups:
+            return [user_data] if user_data else []
+        customer_data = next(
+            (g for g in other_groups if g["notification_group_name"] == "customer"),
+            other_groups[0],
+        )
+        customer_data["notification_group_name"] = "customer"
+        customer_data["recipients"] = [
+            rid for group in other_groups for rid in group["recipients"]
+        ]
+        return [
+            group
+            for group in (user_data, customer_data)
+            if group and group["recipients"]
+        ]
 
     def _notify_thread_by_email(self, message, recipients_data, **kwargs):
         # Pass the whole audience to `_prepare_outgoing_list`

--- a/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
+++ b/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
@@ -69,9 +69,10 @@ class TestMailCcBcc(TestMailComposerForm):
         # Verify recipients of mail.message
         message = self.test_record.message_ids[0]
 
-        # only keep 1 email to avoid clutting db
-        # but actually send 1 mail per recipients
-        self.assertEqual(len(message.mail_ids), 1)
+        # `partner_cc` (Marc Demo) is linked to an internal user, so it gets its
+        # own mail.mail, while the rest of the audience (external) shares a second.
+        # Both still carry the same To/Cc/Bcc headers, checked below.
+        self.assertEqual(len(message.mail_ids), 2)
         self.assertEqual(len(message.recipient_cc_ids), 3)
         self.assertEqual(len(message.recipient_bcc_ids), 1)
         # Verify notification
@@ -83,17 +84,17 @@ class TestMailCcBcc(TestMailComposerForm):
         self.assertEqual(len(notif), 5)
 
         # Verify data of mail.mail
-        mail = message.mail_ids
-        expecting = ", ".join(
+        expecting_cc = ", ".join(
             [
                 '"Marc Demo" <mark.brown23@example.com>',
                 '"Joel Willis" <joel.willis63@example.com>',
                 '"Chester Reed" <chester.reed79@example.com>',
             ]
         )
-        self.assertEqual(mail.email_cc, expecting)
-        expecting = '"Dwayne Newman" <dwayne.newman28@example.com>'
-        self.assertEqual(mail.email_bcc, expecting)
+        expecting_bcc = '"Dwayne Newman" <dwayne.newman28@example.com>'
+        for mail in message.mail_ids:
+            self.assertEqual(mail.email_cc, expecting_cc)
+            self.assertEqual(mail.email_bcc, expecting_bcc)
 
     def test_template_cc_bcc(self):
         env = self.env
@@ -228,7 +229,7 @@ Test Template<br></p>""",
             composer._action_send_mail()
 
         message = self.test_record.message_ids[0]
-        self.assertEqual(len(message.mail_ids), 1)
+        self.assertEqual(len(message.mail_ids), 2)
 
         # Only 4 partners notified
         self.assertEqual(len(message.notified_partner_ids), 4)


### PR DESCRIPTION
Solves https://github.com/OCA/mail/issues/264

Every recipient added through the composer (original recipients, plus the cc/bcc partners) was unconditionally classified as "customer".

A side effect: the "View <record>" button Odoo normally shows to internal user recipients was hidden for everyone, since that button is tied to the "user" notification group, which was never allowed to survive.

Let partners keep their real usage ("user", "portal" or "customer") Internal users now get their own notification email with the button, while external recipients still share a single button-less email. Thus we now have two mail.mail (one for users, and one for the others) sharing the same mail.message.
The To/Cc/Bcc headers stay identical on both, regardless of which notification group produced the mail.mail.